### PR TITLE
feat(web_demo): add repetition_penalty in GenerationConfig in web_demo.py

### DIFF
--- a/web_demo.py
+++ b/web_demo.py
@@ -147,7 +147,8 @@ class GenerationConfig:
     top_p: Optional[float] = None
     temperature: Optional[float] = None
     do_sample: Optional[bool] = True
-    
+    repetition_penalty: Optional[float] = 1.1
+
 
 @st.cache_resource
 def load_model():


### PR DESCRIPTION
* Add the repetition_penalty parameter in the GenerationConfig of web_demo.py, which is used to avoid overly repetitive model generation.