### PR TITLE
fix(chat): fix stream_chat to return generator

### DIFF
--- a/tools/transformers/modeling_internlm.py
+++ b/tools/transformers/modeling_internlm.py
@@ -20,6 +20,7 @@
 """ PyTorch InternLM model."""
 import math
 from typing import List, Optional, Tuple, Union
+import threading, queue
 
 import torch
 import torch.utils.checkpoint
@@ -810,35 +811,70 @@ class InternLMForCausalLM(InternLMPreTrainedModel):
                     temperature: float = 0.8,
                     top_p: float = 0.8,
                     **kwargs):
+        """
+        Return a generator in format: (response, history)
+        Eg.
+        ('你好，有什么可以帮助您的吗', [('你好', '你好，有什么可以帮助您的吗')])
+        ('你好，有什么可以帮助您的吗？', [('你好', '你好，有什么可以帮助您的吗？')])
+        """
+
+        response_queue = queue.Queue(maxsize=20)
+
         class ChatStreamer(BaseStreamer):
             def __init__(self, tokenizer) -> None:
                 super().__init__()
                 self.tokenizer = tokenizer
-                
+                self.queue = response_queue
+                self.query = query
+                self.history = history
+                self.response = ""
+                self.received_inputs = False
+                self.queue.put((self.response, history + [(self.query, self.response)]))
+
             def put(self, value):
                 if len(value.shape) > 1 and value.shape[0] > 1:
                     raise ValueError("ChatStreamer only supports batch size 1")
                 elif len(value.shape) > 1:
                     value = value[0]
+
+                if not self.received_inputs:
+                    # The first received value is input_ids, ignore here
+                    self.received_inputs = True
+                    return
+
                 token = self.tokenizer.decode([value[-1]], skip_special_tokens=True)
                 if token.strip() != "<eoa>":
-                    print(token, end="")
-                
+                    self.response = self.response + token
+                    history = self.history + [(self.query, self.response)]
+                    self.queue.put((self.response, history))
+
             def end(self):
-                print("")
-            
-        return self.chat(
-            tokenizer=tokenizer,
-            query=query,
-            streamer=ChatStreamer(tokenizer=tokenizer),
-            history=history, 
-            max_new_tokens=max_new_tokens,
-            do_sample=do_sample,
-            temperature=temperature,
-            top_p=top_p,
-            **kwargs
-        )
-                
+                self.queue.put(None)
+
+        def stream_producer():
+            return self.chat(
+                tokenizer=tokenizer,
+                query=query,
+                streamer=ChatStreamer(tokenizer=tokenizer),
+                history=history, 
+                max_new_tokens=max_new_tokens,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_p=top_p,
+                **kwargs
+            )
+
+        def consumer():
+            producer = threading.Thread(target=stream_producer)
+            producer.start()
+            while True:
+                res = response_queue.get()
+                if res is not None:
+                    return
+                yield res
+
+        return consumer()
+
 
 @add_start_docstrings(
     """


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The "stream_chat" just return an tuple like (response, history), but stream_chat was supposed to return generator. 

You can refer to function ”def stream_chat“ in https://huggingface.co/THUDM/chatglm-6b/blob/main/modeling_chatglm.py#L1316  return "yield response, new_history"

And project https://github.com/imClumsyPanda/langchain-ChatGLM expect function ”def stream_chat“ to return a generator.

But the implementation in chatglm-6b reuse many logic in huggingface transformers function "def generate" in 
https://github.com/huggingface/transformers/blob/main/src/transformers/generation/utils.py#L1161.

Here juse use a queue to receive responses to be simple.

## Modification

Change  "stream_chat"  to return a generator.

## BC-breaking (Optional)

Change  "stream_chat"  to return a generator.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
