### PR TITLE
feat(solver): fix code to adapt to torch2.0 and provide docker images

### DIFF
--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -57,3 +57,14 @@ cd ./third_party/apex
 pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 cd ../../
 ```
+
+### Environment Image
+Users can obtain an image with the InternLM runtime environment installed from https://hub.docker.com/r/sunpengsdu/internlm. The commands for pulling the image and starting the container are as follows:
+
+```bash
+# pull image
+docker pull sunpengsdu/internlm:torch2.0.1-cuda11.8-flashatten2.0.0-centos
+# start container
+docker run --gpus all -d -it --shm-size=2gb sunpengsdu/internlm:torch2.0.1-cuda11.8-flashatten2.0.0-centos
+docker exec -it mytorch2.0 bash
+```

--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -63,8 +63,8 @@ Users can obtain an image with the InternLM runtime environment installed from h
 
 ```bash
 # pull image
-docker pull sunpengsdu/internlm:torch2.0.1-cuda11.8-flashatten2.0.0-centos
+docker pull sunpengsdu/internlm:torch1.13-cuda11.7-flashatten1.0.5-centos
 # start container
-docker run --gpus all -d -it --shm-size=2gb sunpengsdu/internlm:torch2.0.1-cuda11.8-flashatten2.0.0-centos
-docker exec -it mytorch2.0 bash
+docker run --gpus all -d -it --shm-size=2gb --name myinternlm sunpengsdu/internlm:torch1.13-cuda11.7-flashatten1.0.5-centos
+docker exec -it myinternlm bash
 ```

--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -5,10 +5,10 @@ The required packages and corresponding version are shown as follows:
 - Python == 3.10
 - GCC == 10.2.0
 - MPFR == 4.1.0
-- CUDA == 11.7
-- Pytorch == 1.13.1+cu117
+- CUDA >= 11.7
+- Pytorch >= 1.13.1
 - Transformers >= 4.28.0
-- Flash-Attention == v1.0.5
+- Flash-Attention >= v1.0.5
 - Apex == 23.05
 - GPU with Ampere or Hopper architecture (such as H100, A100)
 - Linux OS

--- a/doc/install.md
+++ b/doc/install.md
@@ -5,10 +5,10 @@
 - Python == 3.10
 - GCC == 10.2.0
 - MPFR == 4.1.0
-- CUDA == 11.7
-- Pytorch == 1.13.1+cu117
+- CUDA >= 11.7
+- Pytorch >= 1.13.1
 - Transformers >= 4.28.0
-- Flash-Attention == v1.0.5
+- Flash-Attention >= v1.0.5
 - Apex == 23.05
 - Ampere或者Hopper架构的GPU (例如H100, A100)
 - Linux OS

--- a/doc/install.md
+++ b/doc/install.md
@@ -62,8 +62,8 @@ cd ../../
 用户可以从 https://hub.docker.com/r/sunpengsdu/internlm 获取安装了 InternLM 运行环境的镜像，拉取镜像及启动容器的命令如下：
 ```bash
 # 拉取镜像
-docker pull sunpengsdu/internlm:torch2.0.1-cuda11.8-flashatten2.0.0-centos
+docker pull sunpengsdu/internlm:torch1.13-cuda11.7-flashatten1.0.5-centos
 # 启动容器
-docker run --gpus all -d -it --shm-size=2gb sunpengsdu/internlm:torch2.0.1-cuda11.8-flashatten2.0.0-centos
-docker exec -it mytorch2.0 bash
+docker run --gpus all -d -it --shm-size=2gb --name myinternlm sunpengsdu/internlm:torch1.13-cuda11.7-flashatten1.0.5-centos
+docker exec -it myinternlm bash
 ```

--- a/doc/install.md
+++ b/doc/install.md
@@ -57,3 +57,13 @@ cd ./third_party/apex
 pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 cd ../../
 ```
+
+### 环境镜像
+用户可以从 https://hub.docker.com/r/sunpengsdu/internlm 获取安装了 InternLM 运行环境的镜像，拉取镜像及启动容器的命令如下：
+```bash
+# 拉取镜像
+docker pull sunpengsdu/internlm:torch2.0.1-cuda11.8-flashatten2.0.0-centos
+# 启动容器
+docker run --gpus all -d -it --shm-size=2gb sunpengsdu/internlm:torch2.0.1-cuda11.8-flashatten2.0.0-centos
+docker exec -it mytorch2.0 bash
+```

--- a/internlm/solver/lr_scheduler.py
+++ b/internlm/solver/lr_scheduler.py
@@ -27,7 +27,7 @@ class WarmupScheduler(_LRScheduler):
 
     def state_dict(self):
         state_dict = {key: value for key, value in self.__dict__.items() if key not in "optimizer"}
-        if isinstance(state_dict["after_scheduler"], _LRScheduler):
+        if isinstance(state_dict["after_scheduler"], (_LRScheduler, _CosineAnnealingLR)):
             state_dict["after_scheduler_type"] = type(state_dict["after_scheduler"]).__name__
             state_dict["after_scheduler_dict"] = state_dict["after_scheduler"].state_dict()
             del state_dict["after_scheduler"]
@@ -40,7 +40,7 @@ class WarmupScheduler(_LRScheduler):
         for key in list(self.__dict__.keys()):
             if key in state_dict:
                 self.__dict__[key] = state_dict[key]
-        if isinstance(self.after_scheduler, _LRScheduler):
+        if isinstance(self.after_scheduler, (_LRScheduler, _CosineAnnealingLR)):
             assert type(self.after_scheduler).__name__ == state_dict["after_scheduler_type"]
             # state_dict['after_scheduler_dict'] = state_dict['after_scheduler'].state_dict()
             self.after_scheduler.load_state_dict(state_dict["after_scheduler_dict"])

--- a/internlm/solver/optimizer/hybrid_zero_optim.py
+++ b/internlm/solver/optimizer/hybrid_zero_optim.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
+import math
 from functools import partial
 
 import amp_C
 import torch
 import torch.distributed as dist
 from apex.multi_tensor_apply import multi_tensor_applier
-from torch._six import inf
 from torch.optim import Optimizer
 
 from internlm.core.context import Config, ParallelMode
@@ -33,6 +33,7 @@ from internlm.utils.logger import get_logger
 from internlm.utils.megatron_timers import megatron_timer as timer
 from internlm.utils.parallel import is_model_parallel_parameter
 
+inf = math.inf
 logger = get_logger(__file__)
 
 


### PR DESCRIPTION
## Motivation

1. Update code to adapt to torch2.0.
2. Publish [public internlm environment image](https://hub.docker.com/r/sunpengsdu/internlm).

## Modification

### 1. fix import error
![image](https://github.com/InternLM/InternLM/assets/20810277/3553917a-7731-4d53-a01f-2439d3e326c9)
![image](https://github.com/InternLM/InternLM/assets/20810277/5829ead1-7613-4601-9c06-1e0e3cbb93ca)
Since torch2.0 has no inf，we use inf in math package:
```python
import math

inf = math.inf
```

### 2. fix lr_scheduler save ckpt error
In torch2.0, class `CosineAnnealingLR` is inherited from class `LRScheduler`, not `_LRScheduler`:
<img width="462" alt="企业微信截图_34f61a8c-f18a-43dc-a0c0-05976564a7d5" src="https://github.com/InternLM/InternLM/assets/20810277/b2296008-b441-4324-803e-9fcd2642434d">

so the `lr_scheduler` instance should be `_LRScheduler(LRScheduler)` or `CosineAnnealingLR(LRScheduler)`


## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
