### PR TITLE
feat(monitor): support monitor and alert

### DIFF
--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -38,6 +38,11 @@ def get_default_parser():
     parser.add_argument("--local_rank", type=int, help="local rank on the node")
     parser.add_argument("--backend", type=str, default="nccl", help="backend for distributed communication")
     parser.add_argument("--seed", type=int, default=1024)
+    parser.add_argument("--job_name", default=None, type=str, help="The training job name.")
+    parser.add_argument(
+        "--monitor", default=False, action="store_true", help="If set True, start monitor and alert thread."
+    )
+    parser.add_argument("--alert_address", default=None, type=str, help="The feishu webhook address for alerting.")
     return parser
 
 

--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -38,11 +38,7 @@ def get_default_parser():
     parser.add_argument("--local_rank", type=int, help="local rank on the node")
     parser.add_argument("--backend", type=str, default="nccl", help="backend for distributed communication")
     parser.add_argument("--seed", type=int, default=1024)
-    parser.add_argument("--job_name", default=None, type=str, help="The training job name.")
-    parser.add_argument(
-        "--monitor", default=False, action="store_true", help="If set True, start monitor and alert thread."
-    )
-    parser.add_argument("--alert_address", default=None, type=str, help="The feishu webhook address for alerting.")
+
     return parser
 
 
@@ -189,6 +185,10 @@ def args_sanity_check():
     # process the model config
     if "use_flash_attn" not in gpc.config.model:
         gpc.config.model._add_item("use_flash_attn", True)
+
+    # feishu webhook address for alerting
+    if "alert_address" not in gpc.config:
+        gpc.config._add_item("alert_address", None)
 
 
 def launch(

--- a/internlm/model/embedding.py
+++ b/internlm/model/embedding.py
@@ -55,10 +55,10 @@ class Embedding1D(nn.Module):
         output_parallel = F.embedding(input_, self.weight, self.padding_idx, *self.embed_args, **self.embed_kwargs)
 
         output = gather_forward_split_backward(output_parallel, ParallelMode.TENSOR, dim=-1)
-        
+
         if gpc.config.model.sequence_parallel:
             output = split_forward_gather_backward(output, ParallelMode.TENSOR, dim=1)
-        
+
         return output
 
 

--- a/internlm/model/linear.py
+++ b/internlm/model/linear.py
@@ -58,7 +58,11 @@ class ScaleColumnParallelLinear(nn.Linear):
         else:
             weight = self.weight
         return fused_dense_func_torch(
-            input, weight, self.bias, process_group=self.process_group, sequence_parallel=gpc.config.model.sequence_parallel
+            input,
+            weight,
+            self.bias,
+            process_group=self.process_group,
+            sequence_parallel=gpc.config.model.sequence_parallel,
         )
 
 
@@ -103,7 +107,11 @@ class RewardModelLinear(ScaleColumnParallelLinear):
         else:
             weight = self.weight
         return fused_dense_func_torch(
-            input, weight, self.bias, process_group=self.process_group, sequence_parallel=gpc.config.model.sequence_parallel
+            input,
+            weight,
+            self.bias,
+            process_group=self.process_group,
+            sequence_parallel=gpc.config.model.sequence_parallel,
         )
 
 
@@ -170,7 +178,13 @@ class FeedForward(nn.Module):
             dtype=dtype,
         )
         self.w2 = ColumnParallelLinearTorch(
-            in_features, hidden_features, process_group, bias, sequence_parallel=gpc.config.model.sequence_parallel, device=device, dtype=dtype
+            in_features,
+            hidden_features,
+            process_group,
+            bias,
+            sequence_parallel=gpc.config.model.sequence_parallel,
+            device=device,
+            dtype=dtype,
         )
         self.w3 = RowParallelLinearTorch(
             hidden_features,

--- a/internlm/model/modeling_internlm.py
+++ b/internlm/model/modeling_internlm.py
@@ -31,6 +31,7 @@ MODEL_TYPE = "INTERNLM"
 logger = get_logger(__file__)
 RMSNorm = try_import_RMSNorm()
 
+
 class PackedFlashBaseLayer1D(nn.Module):
     """
     1D Packed Flash Base Layer.
@@ -461,7 +462,6 @@ def build_model_with_cfg(
     use_scaled_init: bool = True,
     use_swiglu: bool = True,
     use_flash_attn: bool = True,
-    sequence_parallel: bool = False,
 ):
     """
     Builde model with config

--- a/internlm/model/modeling_internlm.py
+++ b/internlm/model/modeling_internlm.py
@@ -462,6 +462,7 @@ def build_model_with_cfg(
     use_scaled_init: bool = True,
     use_swiglu: bool = True,
     use_flash_attn: bool = True,
+    sequence_parallel: bool = False,  # pylint: disable=W0613
 ):
     """
     Builde model with config

--- a/internlm/monitor/__init__.py
+++ b/internlm/monitor/__init__.py
@@ -1,4 +1,4 @@
-from .monitor import send_alert_message, initialize_monitor_manager
+from .monitor import initialize_monitor_manager, send_alert_message
 from .utils import set_env_var
 
 __all__ = ["send_alert_message", "initialize_monitor_manager", "set_env_var"]

--- a/internlm/monitor/__init__.py
+++ b/internlm/monitor/__init__.py
@@ -1,19 +1,4 @@
-from .monitor import (
-    LAST_ACTIVE_TIMESTAMP,
-    initialize_monitor,
-    monitor_exception,
-    monitor_loss_spike,
-    send_alert_message,
-    stop_monitor,
-)
+from .monitor import send_alert_message
 from .utils import set_env_var
 
-__all__ = [
-    "LAST_ACTIVE_TIMESTAMP",
-    "initialize_monitor",
-    "monitor_exception",
-    "monitor_loss_spike",
-    "send_alert_message",
-    "stop_monitor",
-    "set_env_var",
-]
+__all__ = ["send_alert_message", "set_env_var"]

--- a/internlm/monitor/__init__.py
+++ b/internlm/monitor/__init__.py
@@ -1,4 +1,4 @@
-from .monitor import send_alert_message
+from .monitor import send_alert_message, initialize_monitor_manager
 from .utils import set_env_var
 
-__all__ = ["send_alert_message", "set_env_var"]
+__all__ = ["send_alert_message", "initialize_monitor_manager", "set_env_var"]

--- a/internlm/monitor/__init__.py
+++ b/internlm/monitor/__init__.py
@@ -1,6 +1,5 @@
 from .monitor import (
     LAST_ACTIVE_TIMESTAMP,
-    get_process_rank,
     initialize_monitor,
     monitor_exception,
     monitor_loss_spike,
@@ -11,7 +10,6 @@ from .utils import set_env_var
 
 __all__ = [
     "LAST_ACTIVE_TIMESTAMP",
-    "get_process_rank",
     "initialize_monitor",
     "monitor_exception",
     "monitor_loss_spike",

--- a/internlm/monitor/__init__.py
+++ b/internlm/monitor/__init__.py
@@ -1,0 +1,21 @@
+from .monitor import (
+    LAST_ACTIVE_TIMESTAMP,
+    get_process_rank,
+    initialize_monitor,
+    monitor_exception,
+    monitor_loss_spike,
+    send_alert_message,
+    stop_monitor,
+)
+from .utils import set_env_var
+
+__all__ = [
+    "LAST_ACTIVE_TIMESTAMP",
+    "get_process_rank",
+    "initialize_monitor",
+    "monitor_exception",
+    "monitor_loss_spike",
+    "send_alert_message",
+    "stop_monitor",
+    "set_env_var",
+]

--- a/internlm/monitor/alert.py
+++ b/internlm/monitor/alert.py
@@ -1,0 +1,53 @@
+import json
+import time
+
+import requests
+
+
+def send_feishu_msg_with_webhook(webhook: str, title: str, message: str):
+    """
+    Use Feishu robot to send messages with the given webhook.
+
+    Args:
+        webhook (str): The webhook to be used to send message.
+        title (str): The message title.
+        message (str): The message body.
+
+    Returns:
+        The response from the request. Or catch the exception and return None.
+
+    Raises:
+        Exception: An exception rasied by the HTTP post request.
+
+    """
+
+    headers = {"Content-Type": "application/json;charset=utf-8"}
+    msg_body = {
+        "timestamp": int(time.time()),
+        "msg_type": "post",
+        "content": {
+            "post": {
+                "zh_cn": {
+                    "title": title,
+                    "content": [
+                        [
+                            {
+                                "tag": "text",
+                                "text": message,
+                            },
+                        ],
+                    ],
+                },
+            },
+        },
+    }
+
+    try:
+        res = requests.post(webhook, data=json.dumps(msg_body), headers=headers, timeout=30)
+        res = res.json()
+        print(f"Feishu webhook response: {res}")
+    except Exception as err:  # pylint: disable=W0703
+        print(f"HTTP Post error: {err}")
+        res = None
+
+    return res

--- a/internlm/monitor/utils.py
+++ b/internlm/monitor/utils.py
@@ -1,0 +1,58 @@
+import os
+from datetime import datetime
+
+
+def now_time():
+    return datetime.now().strftime("%b%d_%H-%M-%S")
+
+
+def set_env_var(key, value):
+    os.environ[str(key)] = str(value)
+
+
+def get_job_id():
+    job_id = "none"
+    if os.getenv("SLURM_JOB_ID") is not None:
+        job_id = os.getenv("SLURM_JOB_ID")
+    else:
+        job_id = os.getenv("K8S_WORKSPACE_ID")
+
+    return job_id
+
+
+def get_job_name():
+    job_name = f"unknown-{now_time()}"
+    if os.getenv("JOB_NAME") is not None:
+        job_name = os.getenv("JOB_NAME")
+
+    return job_name
+
+
+def get_job_key():
+    return f"{get_job_id()}_{get_job_name()}"
+
+
+def get_process_rank():
+    proc_rank = -1
+    if os.getenv("SLURM_PROCID") is not None:
+        proc_rank = int(os.getenv("SLURM_PROCID"))
+    elif os.getenv("RANK") is not None:
+        # In k8s env, we use $RANK.
+        proc_rank = int(os.getenv("RANK"))
+
+    assert proc_rank != -1, "get_process_rank can not get right process rank!"
+    return proc_rank
+
+
+def get_world_size():
+    # We do not use torch's interface get_world_size to obtain the worldsize to prevent
+    # errors when the init_process_group is not called.
+    if os.getenv("SLURM_NTASKS") is not None:
+        ntasks = int(os.environ["SLURM_NTASKS"])
+    elif os.getenv("WORLD_SIZE") is not None:
+        # In k8s env, we use $WORLD_SIZE.
+        ntasks = int(os.enviro["WORLD_SIZE"])
+    else:
+        ntasks = 1
+
+    return ntasks

--- a/internlm/monitor/utils.py
+++ b/internlm/monitor/utils.py
@@ -14,7 +14,7 @@ def get_job_id():
     job_id = "none"
     if os.getenv("SLURM_JOB_ID") is not None:
         job_id = os.getenv("SLURM_JOB_ID")
-    else:
+    elif os.getenv("K8S_WORKSPACE_ID") is not None:
         job_id = os.getenv("K8S_WORKSPACE_ID")
 
     return job_id
@@ -30,29 +30,3 @@ def get_job_name():
 
 def get_job_key():
     return f"{get_job_id()}_{get_job_name()}"
-
-
-def get_process_rank():
-    proc_rank = -1
-    if os.getenv("SLURM_PROCID") is not None:
-        proc_rank = int(os.getenv("SLURM_PROCID"))
-    elif os.getenv("RANK") is not None:
-        # In k8s env, we use $RANK.
-        proc_rank = int(os.getenv("RANK"))
-
-    assert proc_rank != -1, "get_process_rank can not get right process rank!"
-    return proc_rank
-
-
-def get_world_size():
-    # We do not use torch's interface get_world_size to obtain the worldsize to prevent
-    # errors when the init_process_group is not called.
-    if os.getenv("SLURM_NTASKS") is not None:
-        ntasks = int(os.environ["SLURM_NTASKS"])
-    elif os.getenv("WORLD_SIZE") is not None:
-        # In k8s env, we use $WORLD_SIZE.
-        ntasks = int(os.enviro["WORLD_SIZE"])
-    else:
-        ntasks = 1
-
-    return ntasks

--- a/internlm/solver/optimizer/hybrid_zero_optim.py
+++ b/internlm/solver/optimizer/hybrid_zero_optim.py
@@ -28,6 +28,7 @@ from internlm.solver.optimizer.utils import (
 from internlm.utils.common import get_current_device
 from internlm.utils.logger import get_logger
 from internlm.utils.megatron_timers import megatron_timer as timer
+from internlm.monitor import send_alert_message
 
 from .utils import compute_norm
 
@@ -538,6 +539,7 @@ class HybridZeroOptimizer(BaseOptimizer):
         if found_inf:
             if gpc.is_rank_for_log():
                 logger.warning("Overflow occurs, please check it.")
+                send_alert_message(address=gpc.config.alert_address, message="Overflow occurs, please check it.")
             self._grad_store._averaged_gradients = dict()
             self.zero_grad()
             return False, None

--- a/internlm/utils/common.py
+++ b/internlm/utils/common.py
@@ -34,18 +34,6 @@ def get_master_node():
     return result
 
 
-def get_process_rank():
-    proc_rank = -1
-    if os.getenv("SLURM_PROCID") is not None:
-        proc_rank = int(os.getenv("SLURM_PROCID"))
-    elif os.getenv("RANK") is not None:
-        # In k8s env, we use $RANK.
-        proc_rank = int(os.getenv("RANK"))
-
-    # assert proc_rank != -1, "get_process_rank cant't get right process rank!"
-    return proc_rank
-
-
 def move_norm_to_cuda(norm: Union[float, torch.Tensor]) -> Union[float, torch.Tensor]:
     if torch.is_tensor(norm) and norm.device.type != "cuda":
         norm = norm.to(torch.cuda.current_device())

--- a/internlm/utils/evaluation.py
+++ b/internlm/utils/evaluation.py
@@ -90,19 +90,9 @@ def evaluate_on_val_dls(
                     total_val_bsz = len(batch[1])
                     assert total_val_bsz % data_cfg.micro_bsz == 0
                     num_microbatches = total_val_bsz // data_cfg.micro_bsz
-                    if gpc.config.model.sequence_parallel:
-                        sequence_world_size = gpc.get_world_size(ParallelMode.TENSOR)
-                        tensor_shape = torch.Size(
-                            [
-                                data_cfg.micro_bsz,
-                                batch[0]["input_ids"].shape[1] // sequence_world_size,
-                                gpc.config.HIDDEN_SIZE,
-                            ]
-                        )
-                    else:
-                        tensor_shape = torch.Size(
-                            [data_cfg.micro_bsz, batch[0]["input_ids"].shape[1], gpc.config.HIDDEN_SIZE]
-                        )
+                    tensor_shape = torch.Size(
+                        [data_cfg.micro_bsz, batch[0]["input_ids"].shape[1], gpc.config.HIDDEN_SIZE]
+                    )
 
                     with switch_evaluation_pipeline_scheduler(
                         trainer=trainer,
@@ -118,7 +108,6 @@ def evaluate_on_val_dls(
                     assert total_val_bsz % data_cfg.micro_bsz == 0
                     grad_accum_size = total_val_bsz // data_cfg.micro_bsz
                     grad_accum_batch_size = data_cfg.micro_bsz
-                    # import pdb; pdb.set_trace()
                     with switch_evaluation_no_pipeline_scheduler(
                         trainer=trainer,
                         grad_accum_size=grad_accum_size,

--- a/internlm/utils/evaluation.py
+++ b/internlm/utils/evaluation.py
@@ -6,8 +6,8 @@ from tqdm import tqdm
 
 from internlm.core.context import ParallelMode
 from internlm.core.context import global_context as gpc
-from internlm.model.metrics import AccPerplex
 from internlm.core.scheduler import SchedulerMetricHook
+from internlm.model.metrics import AccPerplex
 
 
 @contextmanager
@@ -93,7 +93,11 @@ def evaluate_on_val_dls(
                     if gpc.config.model.sequence_parallel:
                         sequence_world_size = gpc.get_world_size(ParallelMode.TENSOR)
                         tensor_shape = torch.Size(
-                            [data_cfg.micro_bsz, batch[0]["input_ids"].shape[1] // sequence_world_size, gpc.config.HIDDEN_SIZE]
+                            [
+                                data_cfg.micro_bsz,
+                                batch[0]["input_ids"].shape[1] // sequence_world_size,
+                                gpc.config.HIDDEN_SIZE,
+                            ]
                         )
                     else:
                         tensor_shape = torch.Size(

--- a/train.py
+++ b/train.py
@@ -681,6 +681,8 @@ if __name__ == "__main__":
     except Exception:
         print(f"Raise exception from {hostname} with proc id: {proc_id}")
         traceback.print_exc()
-        monitor_exception(excp_info=traceback.format_exc())
+
+        if proc_id == 0:
+            monitor_exception(excp_info=traceback.format_exc())
     finally:
         stop_monitor()

--- a/train.py
+++ b/train.py
@@ -491,7 +491,7 @@ def main(args):
         model_load_path = load_model_only_folder
     else:
         logger.info(
-            f"===========New Run {current_time} on host:{socket.gethostname()},global_rank={gpc.get_global_rank()}"
+            f"===========New Run {current_time} on host:{socket.gethostname()},rank={gpc.get_global_rank()},"
             f"tp={gpc.get_local_rank(ParallelMode.TENSOR)},pp={gpc.get_local_rank(ParallelMode.PIPELINE)},"
             f"dp={gpc.get_local_rank(ParallelMode.DATA)}==========="
         )

--- a/train.py
+++ b/train.py
@@ -673,6 +673,8 @@ if __name__ == "__main__":
         try:
             main(args)
         except Exception:
-            print(f"Raise exception from {hostname} with rank id: {gpc.get_global_rank()}")
-            traceback.print_exc()
+            logger.error(
+                f"Raise exception from {hostname} with rank id: {gpc.get_global_rank()}",
+                exc_info=traceback.format_exc(),
+            )
             mm.monitor_exception(alert_address=gpc.config.alert_address, excp_info=traceback.format_exc())

--- a/train.py
+++ b/train.py
@@ -427,7 +427,7 @@ def record_current_batch_training_metrics(
             logger.info(line)
 
         # if loss spike occurs, send alert info to feishu
-        monitor_loss_spike(step_count=batch_count, cur_step_loss=loss.item())
+        monitor_loss_spike(alert_address=gpc.config.alert_address, step_count=batch_count, cur_step_loss=loss.item())
 
 
 def main(args):
@@ -686,6 +686,6 @@ if __name__ == "__main__":
         print(f"Raise exception from {hostname} with rank id: {gpc.get_global_rank()}")
         traceback.print_exc()
 
-        monitor_exception(excp_info=traceback.format_exc())
+        monitor_exception(alert_address=gpc.config.alert_address, excp_info=traceback.format_exc())
     finally:
         stop_monitor()

--- a/train.py
+++ b/train.py
@@ -30,7 +30,7 @@ from internlm.data.packed_dataset import (
 from internlm.data.utils import DATASET_TYPE_IDS_MAP, unpack_data
 from internlm.model.loss import FlashGPTLMLoss
 from internlm.model.metrics import AccPerplex
-from internlm.monitor import send_alert_message, set_env_var, initialize_monitor_manager
+from internlm.monitor import initialize_monitor_manager, send_alert_message, set_env_var
 from internlm.monitor.monitor import monitor_manager as mm
 from internlm.solver.beta2_scheduler import Beta2Scheduler
 from internlm.solver.lr_scheduler import FineTuneCosineAnnealingWarmupLR


### PR DESCRIPTION
## Motivation

Monitor training status, loss value, exception status and so on, send alert info to feishu.

## Modification

- `monitor/alert.py`: add func `send_feishu_msg_with_webhook` for sending alert info to feishu.
- `monitor/monitor.py`: add func `initialize_monitor` for initializing monitor thread.

## Use cases (Optional)

User can set feishu webhook alert address in `configs/7B_sft.py`:
```python
# If not set, monitor will be disabled
alert_address = "xxx"
```

Alert info example is shown as follows:
<img width="905" alt="企业微信截图_4feb905d-b2f8-4ce3-b535-930e80da16d9" src="https://github.com/InternLM/InternLM/assets/20810277/125c33cf-0757-4cab-b703-90467a5e1b72">

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.

