### PR TITLE
feat(train.py): support torch profiler

### DIFF
--- a/internlm/utils/common.py
+++ b/internlm/utils/common.py
@@ -218,3 +218,21 @@ def get_megatron_flops(
 
     tflops = flops_per_iteration / (elapsed_time_per_iter * global_world_size * (10**12))
     return tflops
+
+
+class DummyProfile:
+    """
+    Dummy Profile.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, a, b, c):
+        pass
+
+    def step(self):
+        pass


### PR DESCRIPTION
## Motivation

Support torch profiling for analyzing training performance.

## Use cases (Optional)

User set `--profiling` when start training job will enable torch profiling.
```shell
srun -p llm2 --ntasks-per-node=8 --gpus-per-task=1 python train.py --config ./configs/7B_sft.py **--profiling**
```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
