### PR TITLE
fix(embedding):fix fp32 position embedding

### DIFF
--- a/internlm/model/embedding.py
+++ b/internlm/model/embedding.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 
 from typing import Tuple
+from venv import logger
 
 import rotary_emb
 import torch
@@ -137,15 +138,17 @@ class RotaryEmbedding(torch.nn.Module):
         """ """
         super().__init__()
         # Generate and save the inverse frequency buffer (non trainable)
-        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim))
-        self.register_buffer("inv_freq", inv_freq)
+        
+        # In rotary position embeddings, it should not to set inv_freq in the buffer; 
+        # otherwise, it will be set as torch.bfloat16 together with the model.
+        # recommended to define self.inv_freq as a class attribute.
+        self.inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim))
         self.scale_base = scale_base
-        scale = (
+        self.scale = (
             (torch.arange(0, dim, 2, device=device, dtype=torch.float32) + 0.4 * dim) / (1.4 * dim)
             if scale_base > 0
             else None
         )
-        self.register_buffer("scale", scale)
 
         self._seq_len_cached = 0
         self._cos_cached = None


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

RotaryEmbedding.inv_freq will be converted to float16 or bfloat 16 with model when it defined as buffer.

## Modification

Define self.inv_freq as a class attribute.

```
# In rotary position embeddings, it should not to set inv_freq in the buffer; 
# otherwise, it will be set as torch.bfloat16 together with the model.
# define self.inv_freq as a class attribute.
self.inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim))
```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

<img width="500" alt="截屏2023-08-25 23 36 57" src="https://github.com/InternLM/InternLM/assets/25836491/d2ca933d-fbf7-4cbd-bf03-435ddd51b292">


## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
