### PR TITLE
fix(core/trainer.py): fix streaming train state load error

### DIFF
--- a/internlm/core/trainer.py
+++ b/internlm/core/trainer.py
@@ -78,8 +78,9 @@ class TrainState:
         self.step_count = other_stuffs.get("step_count", other_stuffs["batch_count"]) + 1
 
         # track the actual updates of sampler when using weighted sampling
-        self.batch_sampler = train_dl.batch_sampler.copy()
-        self.batch_sampler_iter = iter(self.batch_sampler)
+        if hasattr(self, "batch_sampler"):
+            self.batch_sampler = train_dl.batch_sampler.copy()
+            self.batch_sampler_iter = iter(self.batch_sampler)
 
         # resume tensorboard from older tensorboard_folder
         self.resume_tb_folder = other_stuffs.get("tensorboard_folder", None)


### PR DESCRIPTION
## Motivation

Fix loading model checkpointing error.
<img width="1312" alt="企业微信截图_03acc831-68b0-4b45-b1a9-3d36dfb8de99" src="https://github.com/InternLM/InternLM/assets/20810277/f4c064e0-f560-4ad8-aec0-09e898365703">

## Modification

`core/trainer.py`: skip streaming train state resume batch sampler in class `TrainState::load_state_dict`.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
