### PR TITLE
feat(monitor): add runtime diagnosis

### DIFF
--- a/configs/7B_sft.py
+++ b/configs/7B_sft.py
@@ -20,7 +20,6 @@ LOAD_CKPT_FOLDER = "local:llm_ckpts/49"
 # LOAD_CKPT_FOLDER = f"boto3:s3://model_weights.{BOTO3_IP}/internlm/snapshot/1/"
 CHECKPOINT_EVERY = 50
 ckpt = dict(
-<<<<<<< Updated upstream
     enable_save_ckpt=False,  # enable ckpt save.
     save_ckpt_folder=SAVE_CKPT_FOLDER,  # Path to save training ckpt.
     # load_ckpt_folder= dict(path=MODEL_ONLY_FOLDER, content=["model"], ckpt_type="normal"),
@@ -34,18 +33,6 @@ ckpt = dict(
     async_upload=True,  # async ckpt upload. (only work for boto3 ckpt)
     async_upload_tmp_folder="/dev/shm/internlm_tmp_ckpt/",  # path for temporarily files during asynchronous upload.
     oss_snapshot_freq=int(CHECKPOINT_EVERY / 2),  # snapshot ckpt save frequency.
-=======
-    # enable_save_ckpt=False,  # enable ckpt save.
-    # save_ckpt_folder=SAVE_CKPT_FOLDER,  # Path to save training ckpt.
-    # # load_ckpt_folder=LOAD_CKPT_FOLDER, # Ckpt path to resume training(load weights and scheduler/context states).
-    # # load_model_only_folder=MODEL_ONLY_FOLDER, # Path to initialize with given model weights.
-    # load_optimizer=True,  # Wheter to load optimizer states when continuing training.
-    # checkpoint_every=CHECKPOINT_EVERY,
-    # async_upload=True,  # async ckpt upload. (only work for boto3 ckpt)
-    # async_upload_tmp_folder="/dev/shm/internlm_tmp_ckpt/",  # path for temporarily files during asynchronous upload.
-    # snapshot_ckpt_folder="/".join([SAVE_CKPT_FOLDER, "snapshot"]),  # directory for snapshot ckpt storage path.
-    # oss_snapshot_freq=int(CHECKPOINT_EVERY / 2),  # snapshot ckpt save frequency.
->>>>>>> Stashed changes
 )
 
 TRAIN_FOLDER = "/path/to/dataset"

--- a/configs/7B_sft.py
+++ b/configs/7B_sft.py
@@ -127,6 +127,12 @@ model = dict(
     use_flash_attn=True,
     num_chunks=1,  # if num_chunks > 1, interleaved pipeline scheduler is used.
 )
+
+profiler = dict(
+    torch_active_count=50,
+    memory_active_count=50,
+    diagnosis_active_count=50,
+)
 """
 zero1 parallel:
     1. if zero1 <= 0, The size of the zero process group is equal to the size of the dp process group,

--- a/configs/7B_sft.py
+++ b/configs/7B_sft.py
@@ -130,7 +130,6 @@ model = dict(
     use_flash_attn=True,
     num_chunks=1,  # if num_chunks > 1, interleaved pipeline scheduler is used.
 )
-
 """
 zero1 parallel:
     1. if zero1 <= 0, The size of the zero process group is equal to the size of the dp process group,

--- a/configs/7B_sft.py
+++ b/configs/7B_sft.py
@@ -20,6 +20,7 @@ LOAD_CKPT_FOLDER = "local:llm_ckpts/49"
 # LOAD_CKPT_FOLDER = f"boto3:s3://model_weights.{BOTO3_IP}/internlm/snapshot/1/"
 CHECKPOINT_EVERY = 50
 ckpt = dict(
+<<<<<<< Updated upstream
     enable_save_ckpt=False,  # enable ckpt save.
     save_ckpt_folder=SAVE_CKPT_FOLDER,  # Path to save training ckpt.
     # load_ckpt_folder= dict(path=MODEL_ONLY_FOLDER, content=["model"], ckpt_type="normal"),
@@ -33,6 +34,18 @@ ckpt = dict(
     async_upload=True,  # async ckpt upload. (only work for boto3 ckpt)
     async_upload_tmp_folder="/dev/shm/internlm_tmp_ckpt/",  # path for temporarily files during asynchronous upload.
     oss_snapshot_freq=int(CHECKPOINT_EVERY / 2),  # snapshot ckpt save frequency.
+=======
+    # enable_save_ckpt=False,  # enable ckpt save.
+    # save_ckpt_folder=SAVE_CKPT_FOLDER,  # Path to save training ckpt.
+    # # load_ckpt_folder=LOAD_CKPT_FOLDER, # Ckpt path to resume training(load weights and scheduler/context states).
+    # # load_model_only_folder=MODEL_ONLY_FOLDER, # Path to initialize with given model weights.
+    # load_optimizer=True,  # Wheter to load optimizer states when continuing training.
+    # checkpoint_every=CHECKPOINT_EVERY,
+    # async_upload=True,  # async ckpt upload. (only work for boto3 ckpt)
+    # async_upload_tmp_folder="/dev/shm/internlm_tmp_ckpt/",  # path for temporarily files during asynchronous upload.
+    # snapshot_ckpt_folder="/".join([SAVE_CKPT_FOLDER, "snapshot"]),  # directory for snapshot ckpt storage path.
+    # oss_snapshot_freq=int(CHECKPOINT_EVERY / 2),  # snapshot ckpt save frequency.
+>>>>>>> Stashed changes
 )
 
 TRAIN_FOLDER = "/path/to/dataset"
@@ -131,11 +144,6 @@ model = dict(
     num_chunks=1,  # if num_chunks > 1, interleaved pipeline scheduler is used.
 )
 
-profiler = dict(
-    torch_active_count=50,
-    memory_active_count=50,
-    diagnosis_active_count=50,
-)
 """
 zero1 parallel:
     1. if zero1 <= 0, The size of the zero process group is equal to the size of the dp process group,

--- a/configs/profiler.py
+++ b/configs/profiler.py
@@ -3,7 +3,7 @@ profiler = dict(
     memory_active_count=50,       # Control the frequency of memory profiler
     bench_active_count=50,        # Control the frequency of cuda burn test and nccl-test
     diagnosis_active_count=50,    # Control the frequency of diagnosis
-    
+
     diagnosis_start=10,           # Control the start batch count of diagnosis
-    diagnosis_slower_check=20,    # Control the frequency of checking continuous slower step
+    diagnosis_slower_check=50,    # Control the frequency of checking continuous slower step
 )

--- a/configs/profiler.py
+++ b/configs/profiler.py
@@ -1,0 +1,9 @@
+profiler = dict(
+    torch_active_count=50,        # Control the frequency of torch profiler
+    memory_active_count=50,       # Control the frequency of memory profiler
+    bench_active_count=50,        # Control the frequency of cuda burn test and nccl-test
+    diagnosis_active_count=50,    # Control the frequency of diagnosis
+    
+    diagnosis_start=10,           # Control the start batch count of diagnosis
+    diagnosis_slower_check=20,    # Control the frequency of checking continuous slower step
+)

--- a/internlm/monitor/diagnosis.py
+++ b/internlm/monitor/diagnosis.py
@@ -1,0 +1,272 @@
+import os
+import torch
+import socket
+import functools
+import contextlib
+from internlm.utils.registry import MODEL_INITIALIZER
+from internlm.utils.writer import Writer
+from internlm.utils.megatron_timers import megatron_timer
+from internlm.utils.megatron_timers import megatron_timer as timer
+from typing import Callable, Iterable, Union
+from internlm.utils.logger import get_logger, initialize_uniscale_logger
+from internlm.core.context import ParallelMode
+from internlm.core.context import global_context as gpc
+from internlm.utils.parallel import get_parallel_log_file_name
+from internlm.utils.common import DummyProfile
+from internlm.utils.gputest import bench_gpu, bench_net
+from beautifultable import BeautifulTable
+from collections import defaultdict
+import torch.distributed as dist
+
+
+logger = get_logger(__file__)
+
+# def initialize_llm_logger(start_time: str, do_diagnosis=False):
+#     """
+#     Initialize customed uniscale logger.
+
+#     Args:
+#         start_time (str): The launch time of current training job.
+
+#     Returns: The instance of uniscale logger.
+#     """
+#     print('do_diagnosis', do_diagnosis, flush=True)
+#     uniscale_logger = initialize_uniscale_logger(
+#         job_name=gpc.config.JOB_NAME, launch_time=start_time, file_name=get_parallel_log_file_name(), do_diagnosis=do_diagnosis
+#     )
+#     # if uniscale_logger is not None:
+#     #     global logger
+#     #     logger = uniscale_logger
+
+#     return uniscale_logger
+
+class LLMProfiler:
+    def __init__(
+        self,
+        timer: megatron_timer,
+        train_state,
+        log_time_step: int = 1,
+        launch_time: str = None,
+        active_count: int = 1,
+        do_trace_profiling: bool = False,
+        trace_profiling_range: Callable = None,
+        do_diagnosis: bool = False,
+        writer: Writer = None,
+        current_time = None,
+    ) -> None:
+        """
+        TODO: support PP diagnosis mode.
+
+        Args:
+            timer (megatron_timer): 
+            train_state (_type_): 
+            log_time_step (int, optional): . Defaults to 1.
+            trace_profiling_range (Callable, optional): A user-defined function with a return value of true or false, 
+                used to control whether trace profiling is enabled. Defaults to None.
+            launch_time (str, optional): . Defaults to None.
+            active_count (int, optional): trace profiling interval. Defaults to 1.
+            do_trace_profiling (bool): Whether to enable trace profiling. Defaults to False.
+            do_diagnosis (bool, optional): Whether to enable runtime diagnostics. Defaults to False.
+            writer (Writer, optional): . Defaults to None.
+        """
+        from datetime import datetime
+
+        self.trace_profiling = do_trace_profiling
+        self.train_state = train_state
+        self.active_count = active_count
+        self.in_diagnosis = do_diagnosis
+        self.diagnosis_path = None
+        self.log_time_step = log_time_step
+        self.writer = writer
+        self.timer: megatron_timer = timer
+        self.current_time = current_time
+        # self.uniscale_logger = initialize_llm_logger(start_time=current_time, do_diagnosis=do_diagnosis)
+        self.torch_profile = DummyProfile()
+        # self.avg_vals_dict = defaultdict(lambda: (0, 0))
+        self.rank_avg_time = defaultdict(int)
+        # runtime time metrics.
+        self.time_ckpts = [
+            "batch-gen",
+            "fwd",
+            "bwd",
+            "fwd-bwd",
+            "dp_sync",
+            "post_fn",
+            "cal_loss",
+            "sync_grad",
+            "cal_norm",
+            "step",
+            "one-batch",
+        ]
+
+        if trace_profiling_range is None:
+            trace_profiling_range = (
+                lambda: gpc.get_local_rank(ParallelMode.DATA) == 0 and gpc.get_local_rank(ParallelMode.TENSOR) == 0
+            )
+
+        if launch_time is None:
+            launch_time = datetime.now().strftime("%H:%M:%S")
+
+        if self.trace_profiling:
+            if trace_profiling_range():
+                self.torch_profile = torch.profiler.profile(
+                    activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+                    schedule=torch.profiler.schedule(skip_first=30, wait=1, warmup=1, active=1, repeat=1),
+                    on_trace_ready=torch.profiler.tensorboard_trace_handler(
+                        f"{gpc.config.JOB_NAME}/{launch_time}/traces/",
+                    ),
+                    with_stack=True,
+                    with_modules=True,
+                )
+            else:
+                self.torch_profile = DummyProfile()
+        else:
+            self.torch_profile = DummyProfile()
+        
+        if self.in_diagnosis:
+            log_file_name = 'diagnosis.log'
+            log_folder = os.path.join(gpc.config.JOB_NAME, self.current_time, "logs")
+            log_dir = os.path.join(log_folder, log_file_name)
+            file_path = log_dir
+            self.diagnosis_path = file_path
+            
+    def get_rank_uid(self):
+        return (
+            f"{socket.gethostname()}_rank{gpc.get_global_rank()}_"
+            + f"dp{gpc.get_local_rank(ParallelMode.DATA)}_"
+            + f"tp{gpc.get_local_rank(ParallelMode.TENSOR)}_"
+            + f"pp{gpc.get_local_rank(ParallelMode.PIPELINE)}"
+        )
+
+    def __enter__(self):
+        return self
+    
+    def _print_table(self, all_times):
+        table = BeautifulTable(maxwidth=200)
+        avg_vals_dict = defaultdict(int)
+        for key, values in all_times.items():
+            all_times[key] = sorted(values, key=lambda x: x[0], reverse=True)
+            avg_value = round(sum(x[0] for x in all_times[key]) / len(all_times[key]), 2)
+            avg_vals_dict[key] = avg_value
+            
+            subtable_order = BeautifulTable()
+            subtable_ruid = BeautifulTable()
+            subtable_value = BeautifulTable()
+            
+            order = 1
+            for value, ruid in all_times[key]:
+                if value >= avg_value * 1.05:
+                    subtable_order.rows.append([order])
+                    subtable_ruid.rows.append([ruid])
+                    subtable_value.rows.append([value])
+                    order += 1
+                    
+            subtable_order.border.left = ''
+            subtable_order.border.right = ''
+            subtable_order.border.top = ''
+            subtable_order.border.bottom = ''
+            
+            subtable_ruid.border.left = ''
+            subtable_ruid.border.right = ''
+            subtable_ruid.border.top = ''
+            subtable_ruid.border.bottom = ''
+
+            subtable_value.border.left = ''
+            subtable_value.border.right = ''
+            subtable_value.border.top = ''
+            subtable_value.border.bottom = ''
+            
+            row_header = key + '\n' + f'avg:{avg_value}'
+            table.rows.append([row_header, subtable_order, subtable_ruid, subtable_value])
+        
+        table.columns.header = ['', 'order', 'ruid', 'value']
+        
+        print('batch_count', self.train_state.batch_count)
+        print("Inner-step dia:")
+        print(table)
+        print()
+        
+    def step(self):
+        # Try increase torch trace profiler counter
+        if self.train_state.step_count % self.active_count == 0:
+            self.torch_profile.step()
+
+        # Try dump timer to rb or log.
+        if (self.train_state.step_count + 1) % self.log_time_step == 0:
+            if self.writer:
+                self.timer.write(
+                    self.time_ckpts,
+                    self.writer,
+                    self.train_state.step_count,
+                    normalizer=self.log_time_step,
+                    reset=False,
+                )
+            if gpc.is_rank_for_log():
+                self.timer.log(
+                    names=self.time_ckpts, logger=logger, normalizer=self.log_time_step, reset=False
+                )
+                 
+        # If we are in diagnosis mode, rank 0 will gahter all rank runtime time info.
+        if self.in_diagnosis:
+            global_rank_uid = self.get_rank_uid()
+            time_info = self.timer.get_all_timer_results(reset=False)
+            batch_count = self.train_state.batch_count
+            if batch_count > 10:
+                with open(self.diagnosis_path, 'a') as f:
+                    with contextlib.redirect_stdout(f):
+                        if batch_count % 2 == 0:
+                            time_list = (global_rank_uid, time_info)
+                            if gpc.get_global_rank() == 0:
+                                all_rank_time_list = [None for _ in range(gpc.get_world_size(ParallelMode.GLOBAL))]
+                            else:
+                                all_rank_time_list = None
+                            dist.gather_object(time_list, all_rank_time_list, dst=0, group=gpc.get_group(ParallelMode.GLOBAL))
+                            if gpc.get_global_rank() == 0:
+                                all_times = {}
+                                for rank_time_info in all_rank_time_list:
+                                    ruid, info = rank_time_info
+                                    for time_tuple in info:
+                                        name, value = time_tuple
+                                        if name not in all_times:
+                                            all_times[name] = [(value, ruid)]
+                                        else:
+                                            all_times[name].append((value, ruid))
+                                                                        
+                                self._print_table(all_times)
+                                            
+                        if gpc.get_global_rank() == 0: 
+                            slow_list = []        
+                            for time_tuple in time_info:
+                                name, value = time_tuple
+                                if batch_count % 2 == 0:        
+                                    avg_val = self.rank_avg_time[name]
+                                    if value >= avg_val * 1:
+                                        slow_list.append((name, value, avg_val))
+                                sum_val = self.rank_avg_time[name] * (batch_count - 10) + value
+                                self.rank_avg_time[name] = round(sum_val / (batch_count - 9), 2)
+                                             
+                            
+                            if batch_count % 2 == 0 and slow_list != []:
+                                print('Cross step dia:')
+                                print('This step is slower than average')
+                                for tuple in slow_list:
+                                    name, value, avg_val = tuple
+                                    print(f'{name} = {value} > avg ({avg_val})')
+                                print()
+                        
+                        if batch_count % 2 == 0:
+                            torch.cuda.empty_cache()
+                            bench_gpu()
+                            bench_net()   
+                                     
+                               
+        self.timer.reset()
+
+        # Do cuda burn test
+
+
+        # Do nccl-test benchmark
+
+
+    def __exit__(self, a, b, c):
+        pass

--- a/internlm/monitor/diagnosis.py
+++ b/internlm/monitor/diagnosis.py
@@ -63,6 +63,7 @@ class LLMManager:
         self.memory_profiler = memory_profiler
         self.torch_active_count = None
         self.memory_active_count = None
+        self.bench_active_count = None
         self.diagnosis_active_count = None
         self.diagnosis_start = 10
         self.diagnosis_slower_check = 50
@@ -215,17 +216,7 @@ class LLMManager:
                         time_list = (global_rank_uid, time_info)
                         all_rank_time_list = [None for _ in range(gpc.get_world_size(ParallelMode.GLOBAL))]
                         dist.all_gather_object(all_rank_time_list, time_list, group=gpc.get_group(ParallelMode.GLOBAL))
-
-                        # max_time = torch.tensor(time_list)
-                        # min_time = torch.tensor(time_list)
-                        # sum_time = torch.tensor(time_list)
-                        # dist.all_reduce(max_time, dist.ReduceOp.MAX, group=gpc.get_group(ParallelMode.GLOBAL))
-                        # dist.all_reduce(min_time, dist.ReduceOp.MIN, group=gpc.get_group(ParallelMode.GLOBAL))
-                        # dist.all_reduce(sum_time, dist.ReduceOp.SUM, group=gpc.get_group(ParallelMode.GLOBAL))
-                        # avg_time = (sum_time - min_time - max_time) / gpc.get_world_size(ParallelMode.GLOBAL)
-                        # print('testttt', global_rank_uid, max_time, min_time, sum_time, avg_time)
-                        
-                        
+                    
                         if gpc.is_rank_for_log():
                             all_times = {}
                             for rank_time_info in all_rank_time_list:
@@ -272,7 +263,7 @@ class LLMManager:
 
 
         # Do nccl-test benchmark
-        if batch_count % self.bench_active_count == 0:
+        if self.bench_active_count and batch_count % self.bench_active_count == 0:
             bench_gpu()
             bench_net()
 

--- a/internlm/utils/gputest.py
+++ b/internlm/utils/gputest.py
@@ -6,8 +6,8 @@ import socket
 
 import torch
 import torch.distributed as dist
+import torch.utils.benchmark as benchmark
 from flash_attn.modules.mha import FlashSelfAttention, SelfAttention
-from torch.utils import benchmark
 
 from internlm.utils.logger import get_logger
 
@@ -114,7 +114,13 @@ def bench_net():
     allreduce_time_avg = float(allreduce_time_avg.item())
 
     if allreduce_time_this >= allreduce_time_avg * 1.05:
-        logger.warning(
+        # logger.warning(
+        #     f"Rank {gpc.get_local_rank(ParallelMode.GLOBAL)} NCCL test is slower than avg, "
+        #     f"Hostname {socket.gethostname()}, "
+        #     f"allreduce_time {allreduce_time_this:.2f}, avg {allreduce_time_avg:.2f}, "
+        #     f"CPU temp {get_cpu_temperature()}, GPU temp { get_gpu_temperature()}"
+        # )
+        print(
             f"Rank {gpc.get_local_rank(ParallelMode.GLOBAL)} NCCL test is slower than avg, "
             f"Hostname {socket.gethostname()}, "
             f"allreduce_time {allreduce_time_this:.2f}, avg {allreduce_time_avg:.2f}, "
@@ -155,7 +161,13 @@ def bench_gpu(use_flash_attn=True):
     speed_avg = float(speed_avg.item())
 
     if speed_this <= speed_avg * 0.95:
-        logger.warning(
+        # logger.warning(
+        #     f"Rank {gpc.get_local_rank(ParallelMode.GLOBAL)} GPU is slower than avg, "
+        #     f"Hostname {socket.gethostname()}, "
+        #     f"tflops {speed_this:.2f}, avg {speed_avg:.2f}, "
+        #     f"CPU temp {get_cpu_temperature()}, GPU temp { get_gpu_temperature()}"
+        # )
+        print(
             f"Rank {gpc.get_local_rank(ParallelMode.GLOBAL)} GPU is slower than avg, "
             f"Hostname {socket.gethostname()}, "
             f"tflops {speed_this:.2f}, avg {speed_avg:.2f}, "

--- a/internlm/utils/gputest.py
+++ b/internlm/utils/gputest.py
@@ -114,12 +114,6 @@ def bench_net():
     allreduce_time_avg = float(allreduce_time_avg.item())
 
     if allreduce_time_this >= allreduce_time_avg * 1.05:
-        # logger.warning(
-        #     f"Rank {gpc.get_local_rank(ParallelMode.GLOBAL)} NCCL test is slower than avg, "
-        #     f"Hostname {socket.gethostname()}, "
-        #     f"allreduce_time {allreduce_time_this:.2f}, avg {allreduce_time_avg:.2f}, "
-        #     f"CPU temp {get_cpu_temperature()}, GPU temp { get_gpu_temperature()}"
-        # )
         print(
             f"Rank {gpc.get_local_rank(ParallelMode.GLOBAL)} NCCL test is slower than avg, "
             f"Hostname {socket.gethostname()}, "
@@ -161,12 +155,6 @@ def bench_gpu(use_flash_attn=True):
     speed_avg = float(speed_avg.item())
 
     if speed_this <= speed_avg * 0.95:
-        # logger.warning(
-        #     f"Rank {gpc.get_local_rank(ParallelMode.GLOBAL)} GPU is slower than avg, "
-        #     f"Hostname {socket.gethostname()}, "
-        #     f"tflops {speed_this:.2f}, avg {speed_avg:.2f}, "
-        #     f"CPU temp {get_cpu_temperature()}, GPU temp { get_gpu_temperature()}"
-        # )
         print(
             f"Rank {gpc.get_local_rank(ParallelMode.GLOBAL)} GPU is slower than avg, "
             f"Hostname {socket.gethostname()}, "

--- a/internlm/utils/megatron_timers.py
+++ b/internlm/utils/megatron_timers.py
@@ -74,7 +74,7 @@ class Timers:
                 value = self.timers[name].elapsed(reset=reset) / normalizer
                 writer.add_scalar(f"time/{name}-time", value, iteration)
 
-    def log(self, names, logger, normalizer=1.0, reset=True):
+    def log(self, names, logger, normalizer=1.0, reset=False):
         """Log a group of timers."""
         assert normalizer > 0.0
         string = ""
@@ -89,7 +89,7 @@ class Timers:
         logger.info(string)
         return string
 
-    def debug(self, names, logger, normalizer=1.0, reset=True):
+    def debug(self, names, logger, normalizer=1.0, reset=False):
         """Log a group of timers."""
         assert normalizer > 0.0
         string = ""
@@ -107,6 +107,13 @@ class Timers:
     def reset(self):
         for _, t in self.timers.items():
             t.reset()
+
+    def get_all_timer_results(self, normalizer=1.0, reset=False):
+        assert normalizer > 0.0
+        metric_time_dict = {}
+        for name, tt in self.timers.items():
+            metric_time_dict.update({name: tt.elapsed(reset=reset) * 1000.0 / normalizer})
+        return sorted(metric_time_dict.items(), key=lambda x: x[0])  # sort base on value.
 
 
 megatron_timer = Timers()

--- a/train.py
+++ b/train.py
@@ -192,10 +192,11 @@ def main(args):
     # transfer the train data loader into train data iterator
     train_iter = iter(train_dl)
 
-    with initialize_llm_profile(profiling=args.profiling, start_time=current_time) as prof:
+    with LLMProfiler(
+        timer=timer, train_state=train_state, launch_time=launch_time, do_diagnosis=True, writer=writer, current_time=current_time
+    ) as prof:
         # start iterating the train data and begin training
         for batch_count in range(train_state.batch_count, total_steps):
-
             start_time = time.time()
             timer("one-batch").start()
 
@@ -281,8 +282,9 @@ def main(args):
 
             if memory_profiler is not None:
                 memory_profiler.step()
-
             prof.step()
+
+                
 
     ckpt_manager.wait_async_upload_finish()
 

--- a/train.py
+++ b/train.py
@@ -195,10 +195,6 @@ def main(args):
     with initialize_llm_profile(profiling=args.profiling, start_time=current_time) as prof:
         # start iterating the train data and begin training
         for batch_count in range(train_state.batch_count, total_steps):
-            if batch_count % 50 == 0:
-                torch.cuda.empty_cache()
-                bench_gpu()
-                bench_net()
 
             start_time = time.time()
             timer("one-batch").start()
@@ -286,8 +282,7 @@ def main(args):
             if memory_profiler is not None:
                 memory_profiler.step()
 
-            if batch_count % 2 == 0:
-                prof.step()
+            prof.step()
 
     ckpt_manager.wait_async_upload_finish()
 

--- a/train.py
+++ b/train.py
@@ -4,12 +4,14 @@
 import socket
 import time
 import traceback
+import collections
 from functools import partial
 
 import torch
 import torch.distributed as dist
 
 import internlm
+from internlm.monitor.diagnosis import LLMManager
 from internlm.core.context import ParallelMode
 from internlm.core.context import global_context as gpc
 from internlm.core.scheduler import SchedulerMetricHook
@@ -190,8 +192,13 @@ def main(args):
     # transfer the train data loader into train data iterator
     train_iter = iter(train_dl)
 
-    with LLMProfiler(
-        timer=timer, train_state=train_state, launch_time=launch_time, do_diagnosis=True, writer=writer, current_time=current_time
+    with LLMManager(
+        timer=timer,
+        train_state=train_state,
+        writer=writer,
+        current_time=current_time,
+        memory_profiler=memory_profiler,
+        do_trace_profiling=args.profiling,
     ) as prof:
         # start iterating the train data and begin training
         for batch_count in range(train_state.batch_count, total_steps):
@@ -282,8 +289,6 @@ def main(args):
             if now_break:
                 break
 
-            if memory_profiler is not None:
-                memory_profiler.step()
             prof.step()
 
                 


### PR DESCRIPTION
## Motivation
Modify `llm_profiler` to manage the training main loop using a context manager. Use the `.step()` function to periodically execute the routine's operations. This allows various runtime diagnostic operations to be performed without stopping the task.

## Modification
1. LLMProfiler
2. internlm/utils/megatron_timers.py

TODO Features:
1. - [x] Runtime GPU computational capability detection (already completed by @sunpengsdu . Available in [public repository branch](https://github.com/InternLM/InternLM/compare/main...feat/add_runntime_gpu_test))
3. - [x] Runtime nccl-test
4. - [ ] Runtime slow node collection and output for topK (rank0 gathers fwd, bwd, etc. timing metrics from all processes, sorts and outputs the slowest k ranks along with corresponding hostnames)
5. - [ ] Runtime slow trace analysis (Based on feature 3, after identifying slow nodes, targeted trace collection can be enabled on those nodes to avoid excessive and useless trace output)
6. - [ ] Runtime synchronization communication wait time analysis (In different stages, such as fwd, bwd, step intervals, add barriers, collect the time each rank executes the barrier, identify slow communication nodes. This can be implemented through a hook to intercept communication functions)
7. - [ ] Runtime GPU memory profiling
8. - [ ] Add external switch to llm_profiler at runtime (such as polling a file every 50 steps) to control enabling and disabling of diagnostic features
9. - [ ] (Code structure optimization) Move all non-critical routine operations into the step function of the context manager
10. - [ ] Separate diagnostic logs from training logs

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
