### PR TITLE
fix(metric): reset argument missing in getting loss metrics.

### DIFF
--- a/internlm/model/metrics.py
+++ b/internlm/model/metrics.py
@@ -176,7 +176,7 @@ class AccPerplex:
             res.update(ds_acc)
             res.update(ds_tokens)
 
-        loss_res = self.loss_with_type_id.get_metric()
+        loss_res = self.loss_with_type_id.get_metric(reset)
         res.update(loss_res)
 
         return res


### PR DESCRIPTION
## Motivation

In the call to AccPerplex, if `reset=False`, the loss metrics will still be reset. To address this, the `reset` argument needs to be passed to `LossWithTypeId::get_metric`.

![20230831174039](https://github.com/InternLM/InternLM/assets/43229014/87503c80-28e4-4252-9ccb-610a7cf5241b)


## Modification

/internlm/model/metrics.py: add `reset` argument when calling the `LossWithTypeId::get_metric` in line 179.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.

