### PR TITLE
fix(core/context): use dummy mode to generate random numbers in model construction

### DIFF
--- a/internlm/core/context/parallel_context.py
+++ b/internlm/core/context/parallel_context.py
@@ -36,7 +36,7 @@ class Config(dict):
         config (dict): The dict object to be wrapped.
     """
 
-    def __init__(self, config: dict = None):
+    def __init__(self, config: dict = None):  # pylint: disable=W0231
         if config is not None:
             for k, v in config.items():
                 self._add_item(k, v)
@@ -100,7 +100,7 @@ class Config(dict):
 
         module_name = filepath.stem
         source_file = SourceFileLoader(fullname=str(module_name), path=str(filepath))
-        module = source_file.load_module()  # pylint: disable=W4902,E1120
+        module = source_file.load_module()  # pylint: disable=W4902,E1120,W1505
 
         # load into config
         config = Config()
@@ -526,6 +526,7 @@ class ParallelContext(metaclass=SingletonMeta):
         if dpseed_with_tpoffset:
             dp_seed = seed + pipeline_offset * 1024
         add_seed(ParallelMode.DATA, dp_seed)
+        add_seed(ParallelMode.DUMMY, dp_seed)
 
         # model parallel seeds are different across ranks
         if self.is_initialized(ParallelMode.TENSOR):
@@ -533,7 +534,11 @@ class ParallelContext(metaclass=SingletonMeta):
             tp_seed = seed + tp_rank + pipeline_offset * 1024
             add_seed(ParallelMode.TENSOR, tp_seed)
 
-        set_mode(ParallelMode.DATA)
+        # we do not set the random state mode to ParallelMode.DUMMY until model is built, this is because
+        # the random state will be different in diffenent tensor parallel device of the same data parallel
+        # group. The underlying reason is that the device of tp_rank = 0 will perform additional random
+        # operations during the RowParallelLinear module building process.
+        set_mode(ParallelMode.DUMMY)
 
         seeds = get_seeds()
         seed_str = ", ".join([f"{k}: {v}" for k, v in seeds.items()])

--- a/internlm/core/context/parallel_context.py
+++ b/internlm/core/context/parallel_context.py
@@ -534,10 +534,10 @@ class ParallelContext(metaclass=SingletonMeta):
             tp_seed = seed + tp_rank + pipeline_offset * 1024
             add_seed(ParallelMode.TENSOR, tp_seed)
 
-        # we do not set the random state mode to ParallelMode.DUMMY until model is built, this is because
-        # the random state will be different in diffenent tensor parallel device of the same data parallel
-        # group. The underlying reason is that the device of tp_rank = 0 will perform additional random
-        # operations during the RowParallelLinear module building process.
+        # we do not set the random state mode to ParallelMode.DATA until model is built (instead, we use a dummy mode
+        # during model construction), this is because the random state will be different in different tensor parallel
+        # device of the same data parallel group. The underlying reason is that the device of tp_rank = 0 will perform
+        # additional random operations during the RowParallelLinear module building process.
         set_mode(ParallelMode.DUMMY)
 
         seeds = get_seeds()

--- a/internlm/core/context/process_group_initializer.py
+++ b/internlm/core/context/process_group_initializer.py
@@ -35,6 +35,9 @@ class ParallelMode(Enum):
     # runntime network test
     NETTEST = "nettest"
 
+    # dummy mode, only used during mode construction
+    DUMMY = "dummy"
+
 
 class ProcessGroupInitializer(ABC):
     """An object, knowing the parallelism configuration, that initializes parallel groups.

--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -12,6 +12,7 @@ from torch.utils.data import ConcatDataset, DataLoader
 
 from internlm.core.context import ParallelMode
 from internlm.core.context import global_context as gpc
+from internlm.core.context.random import set_mode
 from internlm.core.naive_amp import NaiveAMPModel
 from internlm.core.trainer import TrainState
 from internlm.data.batch_sampler import StaticBatchSampler, get_dpsampler_dataloader
@@ -79,6 +80,10 @@ def initialize_model():
     # This function is needed to make sure parameters that are not splitted by tensor parallelism are
     # the same across tensor parallelism.
     sync_model_param_within_tp(model)
+
+    # Change random state mode to ParallelMode.DATA after model is built, guaranteeing the random
+    # state in the same dp group are all the same.
+    set_mode(ParallelMode.DATA)
 
     return model
 

--- a/train.py
+++ b/train.py
@@ -12,7 +12,6 @@ import torch.distributed as dist
 import internlm
 from internlm.core.context import ParallelMode
 from internlm.core.context import global_context as gpc
-from internlm.core.context.random import set_mode
 from internlm.core.scheduler import SchedulerMetricHook
 from internlm.core.trainer import TrainState
 from internlm.initialize import initialize_distributed_env
@@ -102,9 +101,6 @@ def main(args):
 
     # initialize model
     model = initialize_model()
-
-    # change random state mode to ParallelMode.DATA
-    set_mode(ParallelMode.DATA)
 
     with open(args.config, "r") as f:
         config_lines = f.readlines()

--- a/train.py
+++ b/train.py
@@ -12,6 +12,7 @@ import torch.distributed as dist
 import internlm
 from internlm.core.context import ParallelMode
 from internlm.core.context import global_context as gpc
+from internlm.core.context.random import set_mode
 from internlm.core.scheduler import SchedulerMetricHook
 from internlm.core.trainer import TrainState
 from internlm.initialize import initialize_distributed_env
@@ -101,6 +102,9 @@ def main(args):
 
     # initialize model
     model = initialize_model()
+
+    # change random state mode to ParallelMode.DATA
+    set_mode(ParallelMode.DATA)
 
     with open(args.config, "r") as f:
         config_lines = f.readlines()


### PR DESCRIPTION
## Motivation
    
Since the random state will be different in different tensor parallel device of the same data parallel group, here we do not set the random state mode to ParallelMode.Data until model is built(instead, we use a dummy mode during model construction and switch the random state to ParallelMode.Data when model is built). The underlying reason is that the device of tp_rank = 0 will perform additional random operations during the RowParallelLinear module building process.

## Modification


internlm/core/context/process_group_initializer.py: add dummy mode in line 39.
internlm/core/context/parallel_context.py: set seed for dummy mode in line 529 and set to dummy mode in line 541
internlm/train/training_internlm.py:  set random state to data mode when model is built in line 86

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
