### PR TITLE
fix(convert2hf.py): fix the `rotary_emb.inv_freq` KeyError

### DIFF
--- a/tools/transformers/convert2hf.py
+++ b/tools/transformers/convert2hf.py
@@ -38,7 +38,7 @@ def convert2hf(model_config, states_tp_pps):
         current_states["lm_head.weight"] = states.pop("head.weight")
 
         for i in range(model_config["num_layers"]):
-            states.pop(f"blocks.{i}.mixer.rotary_emb.inv_freq")
+            states.pop(f"blocks.{i}.mixer.rotary_emb.inv_freq", None)
 
             wqkv = states.pop(f"blocks.{i}.mixer.Wqkv.weight").reshape(
                 3, model_config["num_attention_heads"], -1, model_config["hidden_size"]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix KeyError that occurred in [convert2hf.py](https://github.com/InternLM/InternLM/blob/main/tools/transformers/convert2hf.py#L41).

I also meet the problem that [issue](https://github.com/InternLM/InternLM/issues/296) reports.

## Modification

Add a default value `None` to the `states.pop` function. 

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
