### PR TITLE
feat(moe): add  local data parallel support for experts

### DIFF
--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -73,6 +73,9 @@ def args_sanity_check():
     if "tensor" not in gpc.config.parallel:
         gpc.config.parallel._add_item("tensor", 1)
 
+    if "expert" not in gpc.config.parallel:
+        gpc.config.parallel._add_item("expert", -1)
+
     # processing the data config in gpc
     data = gpc.config.data
 

--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -73,9 +73,6 @@ def args_sanity_check():
     if "tensor" not in gpc.config.parallel:
         gpc.config.parallel._add_item("tensor", 1)
 
-    if "expert" not in gpc.config.parallel:
-        gpc.config.parallel._add_item("expert", -1)
-
     # processing the data config in gpc
     data = gpc.config.data
 

--- a/internlm/solver/optimizer/store.py
+++ b/internlm/solver/optimizer/store.py
@@ -38,11 +38,15 @@ class BucketStore(BaseStore):
         self._grads = dict()
         self._params = dict()
         self._num_elements_in_bucket = dict()
+        self._dp_parallel_mode = dp_parallel_mode
 
         self.reset()
 
     def num_elements_in_bucket(self, reduce_rank: int = None):
         return self._num_elements_in_bucket[reduce_rank]
+
+    def get_dp_parallel_mode(self):
+        return self._dp_parallel_mode
 
     def add_num_elements_in_bucket(self, num_elements, reduce_rank: int = None):
         self._num_elements_in_bucket[reduce_rank] += num_elements

--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -80,7 +80,7 @@ def initialize_model():
     # This sync is very important, cause the model weights kept in optimizer are copied
     # from the origin parameters in the memory, so we should make sure the dp sync
     # does not influence the model weights in optimizer be different with the origin parameters.
-    sync_model_param(model, parallel_mode=ParallelMode.DATA)
+    sync_model_param(model)
 
     # This function is needed to make sure parameters that are not splitted by tensor parallelism are
     # the same across tensor parallelism.

--- a/internlm/utils/parallel.py
+++ b/internlm/utils/parallel.py
@@ -12,48 +12,23 @@ def is_model_parallel_parameter(p):
     return hasattr(p, IS_TENSOR_PARALLEL) and getattr(p, IS_TENSOR_PARALLEL)
 
 
-def sync_model_param(model, parallel_mode):
+def sync_model_param(model):
     r"""Make sure data parameters are consistent during Data Parallel Mode.
 
     Args:
         model (:class:`torch.nn.Module`): A pyTorch model on whose parameters you check the consistency.
-        parallel_mode (:class:`internlm.core.context.ParallelMode`): Parallel mode to be checked.
     """
-    if gpc.is_initialized(parallel_mode) and gpc.get_world_size(parallel_mode) > 1:
+    if gpc.is_initialized(ParallelMode.DATA) and gpc.get_world_size(ParallelMode.DATA) > 1:
+        sync_moe_param = (
+            gpc.is_initialized(ParallelMode.EXPERT_DATA) and gpc.get_world_size(ParallelMode.EXPERT_DATA) > 1
+        )
         for param in model.parameters():
-            if is_moe_param(param):
-                # TODO: moe expert param need to sync in expert data parallel group
-                # now we do not support expert data parallel
-                pass
+            if sync_moe_param and is_moe_param(param):
+                ranks = gpc.get_ranks_in_group(ParallelMode.EXPERT_DATA)
+                dist.broadcast(param, src=ranks[0], group=gpc.get_group(ParallelMode.EXPERT_DATA))
             else:
-                ranks = gpc.get_ranks_in_group(parallel_mode)
-                dist.broadcast(param, src=ranks[0], group=gpc.get_group(parallel_mode))
-
-
-def sync_tensor(tensor, parallel_mode):
-    r"""Make sure data tensor(parameters) are consistent during Data and Expert Parallel Mode.
-
-    Args:
-        tensor (:class:`torch.Tensor`): A parameters you check the consistency.
-        parallel_mode (:class:`internlm.core.context.ParallelMode`): Parallel mode to be checked.
-    """
-    if gpc.is_initialized(parallel_mode) and gpc.get_world_size(parallel_mode) > 1:
-        ranks = gpc.get_ranks_in_group(parallel_mode)
-        dist.broadcast(tensor, src=ranks[0], group=gpc.get_group(parallel_mode))
-
-
-# TODO: will be used in expert data parallel, may can also used in sync_model_param_within_tp
-def sync_model_param_with_ep(model):
-    r"""Make sure data parameters are consistent during Data Parallel Mode.
-
-    Args:
-        model (:class:`torch.nn.Module`): A pyTorch model on whose parameters you check the consistency.
-    """
-    for param in model.parameters():
-        if is_moe_param(param):
-            sync_tensor(param, ParallelMode.EXPERT_DATA)
-        else:
-            sync_tensor(param, ParallelMode.DATA)
+                ranks = gpc.get_ranks_in_group(ParallelMode.DATA)
+                dist.broadcast(param, src=ranks[0], group=gpc.get_group(ParallelMode.DATA))
 
 
 def sync_model_param_within_tp(model):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Make MoE available  when number of experts is smaller than dp size. In this case, each expert is shared between its local dp group, e.g. when global dp size is 4 (the devices are labeled as 0,1,2,3) and number of experts is 2, then devices 0 and 2 will have shared  expert A, devices 1 and 3 will have shared  expert B. 

## Modification

Please briefly describe what modification is made in this PR.

1. parallel_context.py: set expert communication group and expert_data communication group. The expert group will perform all-to-all communication during different experts in the forward and backward pass, while the expert_data group will perform all_reduce to sync the shared expert grads (meaning all_reduce ops in the local dp).
2. hybrid_zero_optim.py: split the origin bucket_store into moe_bucket and non-moe bucket. The grads in non-moe bucket will perform all_reduce in the global dp world, just as the old codes do. The grads in moe bucket will perform all_reduce in the local dp world (the expert_data group).
3. utils/parallel.py: sync moe parameter in the local dp group (the expert_data group)
4. *have not impl zero for moe parameter*

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
