### PR TITLE
fix(record): fix moe_loss as none for panel_metrics

### DIFF
--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -485,7 +485,8 @@ def record_current_batch_training_metrics(
                 "perplexity": acc_perplex["perplexity"],
                 "fwd_bwd_time": fwd_bwd_time,
             }
-            panel_metrics["moe_loss"] = moe_loss.item()
+            if moe_loss is not None:
+                panel_metrics["moe_loss"] = moe_loss.item()
             for norm_key, norm_value in grad_norm.items():
                 panel_metrics[norm_key] = norm_value
 


### PR DESCRIPTION
## Motivation

There is a bug for dense training in `internlm/train/training_internlm.py`.

 
## Modification

Fix the moe_loss as none for recording into panel_metrics in `internlm/train/training_internlm.py`.

## BC-breaking (Optional)

No.

## Use cases (Optional)

No.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
