### PR TITLE
fix(init): allow resume_tb_folder to be an empty string

### DIFF
--- a/internlm/utils/writer.py
+++ b/internlm/utils/writer.py
@@ -42,8 +42,8 @@ def init_tb_writer(
         # dir of the last task by 'make_launch_script.sh'.
         # If we load ckpt, 'resume_tb_folder' will be overwritten as the
         # reloaded 'train_state.resume_tb_folder'.s
-        if resume_tb_folder is not None:
-            assert len(resume_tb_folder) > 0 and resume_tb_folder != "/"
+        if resume_tb_folder is not None and len(resume_tb_folder) > 0:
+            assert resume_tb_folder != "/"
             if not os.path.exists(resume_tb_folder):
                 logger.error(
                     f"Can't found resume_tb_folder{resume_tb_folder}, \


### PR DESCRIPTION
## Motivation
allow `resume_tb_folder` to be an empty string, related to https://github.com/pjlab-sys4nlp/train_internlm/issues/231

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
