### PR TITLE
fix(monitor):make MonitorTracker thread to daemon

### DIFF
--- a/internlm/monitor/monitor.py
+++ b/internlm/monitor/monitor.py
@@ -53,6 +53,7 @@ class MonitorTracker(Thread):
         self.last_active_time = -1
         self.last_loss_value = -1
         self.stopped = False
+        self.daemon = True
         self.start()
 
     def run(self):


### PR DESCRIPTION
## Motivation

Making `MonitorTracker` thread to daemon，not block the main thread to exit after training finished.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
