### PR TITLE
feat(optimizer): support layer gradient norm

### DIFF
--- a/internlm/core/context/parallel_context.py
+++ b/internlm/core/context/parallel_context.py
@@ -150,6 +150,7 @@ class ParallelContext(metaclass=SingletonMeta):
         self.virtual_pipeline_parallel_size = None
         self.virtual_pipeline_parallel_rank = None
         self._expert_parallel_group_names = []
+        self.layer_names = {"unknown", "embedding", "norm", "head"}
 
     @property
     def config(self):

--- a/internlm/core/context/parallel_context.py
+++ b/internlm/core/context/parallel_context.py
@@ -150,7 +150,7 @@ class ParallelContext(metaclass=SingletonMeta):
         self.virtual_pipeline_parallel_size = None
         self.virtual_pipeline_parallel_rank = None
         self._expert_parallel_group_names = []
-        self.layer_names = {"unknown", "embedding", "norm", "head"}
+        self.layer_names = ["unknown"]
 
     @property
     def config(self):

--- a/internlm/core/engine.py
+++ b/internlm/core/engine.py
@@ -115,7 +115,7 @@ class Engine:
         self._all_reduce_gradients()
         self.optimizer.clip_grad_norm(self.model, self._clip_grad_norm)
 
-        success, grad_norm = self.optimizer.step()
+        success, grad_norm, layer_grad_norm = self.optimizer.step()
 
         if success and self._lr_scheduler is not None:
             self._lr_scheduler.step()
@@ -123,7 +123,7 @@ class Engine:
         if success and self._beta2_scheduler is not None:
             self._beta2_scheduler.step()
 
-        return success, grad_norm
+        return success, grad_norm, layer_grad_norm
 
     def train(self):
         """Sets the model to training mode."""

--- a/internlm/model/modeling_moe.py
+++ b/internlm/model/modeling_moe.py
@@ -26,6 +26,7 @@ from internlm.solver.pipeline_utils import partition_uniform
 from internlm.utils.checkpoint import activation_checkpoint
 from internlm.utils.common import filter_kwargs
 from internlm.utils.logger import get_logger
+from internlm.utils.parallel import set_model_params_layer_name
 from internlm.utils.registry import MODEL_INITIALIZER
 
 MODEL_TYPE = "INTERNLM_MoE"
@@ -515,6 +516,21 @@ def _build_generic_model_1d(num_layers, num_chunks, device=torch.device("cuda"),
     parts = all_parts[pipeline_rank]
     if gpc.is_rank_for_log():
         logger.info(f"The layer sharding is {all_parts}.")
+
+    # config gpc.layer_name
+    # get names of first and last layers
+    kwargs["num_layers"] = 1
+    kwargs["device"] = device
+    kwargs["first"] = True
+    kwargs["last"] = True
+    kwargs["start_layer_idx"] = 0
+    tmp_chunk = PackedFlashInternLm1D(**filter_kwargs(PackedFlashInternLm1D.__init__, kwargs)).cpu()
+    # get names of middle layers
+    for idx in range(num_layers):
+        layer_name = f"{PackedFlashBaseLayer1D.__name__}.{idx}"
+        gpc.layer_names.append(layer_name)
+    set_model_params_layer_name(tmp_chunk)
+    torch.cuda.empty_cache()
 
     models = []
 

--- a/internlm/solver/optimizer/utils.py
+++ b/internlm/solver/optimizer/utils.py
@@ -319,7 +319,7 @@ def compute_norm(
             dist.all_reduce(total_layer_norms_values, op=dist.ReduceOp.SUM, group=gpc.get_group(ParallelMode.MODEL))
         dist.all_reduce(total_layer_norms_values, op=dist.ReduceOp.SUM, group=gpc.get_group(zero_mode))
 
-        for idx in range(len(total_layer_norms_keys)):
+        for idx, layer_name in enumerate(total_layer_norms.keys()):
             layer_norm = total_layer_norms_values[idx]
             if torch.is_tensor(layer_norm):
                 layer_norm = layer_norm.item()
@@ -328,7 +328,7 @@ def compute_norm(
 
             if math.isnan(layer_norm):
                 layer_norm = -2
-            total_layer_norms[total_layer_norms_keys[idx]] = layer_norm
+            total_layer_norms[layer_name] = layer_norm
 
     return total_layer_norms
 

--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -405,6 +405,7 @@ def record_current_batch_training_metrics(
     loss,
     moe_loss,
     grad_norm,
+    layer_grad_norm,
     metric,
     update_panel,
 ):
@@ -525,6 +526,11 @@ def record_current_batch_training_metrics(
                 writer.add_scalars(key=key, value=value, step=train_state.step_count)
             else:
                 writer.add_scalar(key=key, value=value, step=train_state.step_count)
+
+        # add layer grad norm
+        for key, value in layer_grad_norm.items():
+            title = f"layer_grad_norm_group_{key}"
+            writer.add_scalars(key=title, value=value, step=train_state.step_count)
 
         if gpc.config.monitor.alert.get("light_monitor_address", None) and batch_count % 50 == 0:
             send_heartbeat("train_metrics", infos)

--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -52,7 +52,11 @@ from internlm.train.utils import create_param_groups
 from internlm.utils.common import DummyProfile
 from internlm.utils.logger import get_logger
 from internlm.utils.megatron_timers import megatron_timer as timer
-from internlm.utils.parallel import sync_model_param, sync_model_param_within_tp
+from internlm.utils.parallel import (
+    set_model_params_layer_name,
+    sync_model_param,
+    sync_model_param_within_tp,
+)
 from internlm.utils.registry import MODEL_INITIALIZER
 from internlm.utils.timeout import llm_timeout
 
@@ -106,6 +110,9 @@ def initialize_model():
 
     # if fsdp enabled, wrap the model
     model = wrap_FSDP_model(model)
+
+    # set the layer name as an attribute of the model parameters
+    set_model_params_layer_name(model)
 
     return model
 

--- a/internlm/utils/parallel.py
+++ b/internlm/utils/parallel.py
@@ -78,14 +78,16 @@ def set_model_params_layer_name(model):
         if isinstance(_chunk, NaiveAMPModel):
             _chunk = _chunk.model
         # Create a unique layer name based on the block's class name and index
-        for name, children in _chunk.named_children():
+        for _, children in _chunk.named_children():
             if isinstance(children, nn.ModuleList):
                 for idx, block in enumerate(children):
                     for param in block.parameters():
                         layer_name = f"{block.__class__.__name__}.{idx}"
-                        gpc.layer_names.add(layer_name)
+                        gpc.layer_names.append(layer_name)
                         param.__setattr__("layer_name", layer_name)
             else:
                 for param in children.parameters():
-                    gpc.layer_names.add(name)
-                    param.__setattr__("layer_name", name)
+                    layer_name = f"{children.__class__.__name__}"
+                    gpc.layer_names.append(layer_name)
+                    param.__setattr__("layer_name", layer_name)
+    gpc.layer_names = sorted(set(gpc.layer_names))

--- a/tests/test_training/test_loss.py
+++ b/tests/test_training/test_loss.py
@@ -1,6 +1,5 @@
 import math
 import os
-import subprocess
 
 import pytest
 import torch
@@ -198,7 +197,6 @@ def train(
             )
         if gpc.is_rank_for_log():
             assert loss is not None and not math.isnan(loss.item())
-            global cur_loss_list
             cur_loss_list.append((loss.item() - moe_loss.item() if moe_loss is not None else loss.item()))
         timer("fwd-bwd").stop()
 
@@ -206,7 +204,7 @@ def train(
         trainer_result = trainer.step()
         assert trainer_result is not None
 
-        success_update, _ = trainer_result
+        success_update, _, _ = trainer_result
         assert success_update, "Error: grad norm inf or nan occurs!"
         if success_update:  # update parameters successfully
             train_state.step_count += 1

--- a/train.py
+++ b/train.py
@@ -240,7 +240,7 @@ def main(args):
             trainer_result = trainer.step()
             assert trainer_result is not None
 
-            success_update, grad_norm_groups = trainer_result
+            success_update, grad_norm_groups, layer_grad_norm_groups = trainer_result
             if success_update:  # update parameters successfully
                 train_state.step_count += 1
             else:
@@ -268,6 +268,7 @@ def main(args):
                 loss=loss,
                 moe_loss=moe_loss,
                 grad_norm=grad_norm_groups,
+                layer_grad_norm=layer_grad_norm_groups,
                 metric=metric,
                 update_panel=uniscale_logger is not None,
             )


### PR DESCRIPTION

## Motivation
1. Support layer gradient norm and use it instead of total gradient norm.
2. Add layer gradient norm to Tensorboard.

## Modification

`internlm/core/engine.py`
`internlm/solver/optimizer/hybrid_zero_optim.py`
`internlm/solver/optimizer/utils.py`
`internlm/train/training_internlm.py`
`train.py`


- [x] Align gradient norm precision.
- [x] Test on the 7B case and the MoE case.
