### PR TITLE
fix(utils): disable runtime nccl diagnosis

### DIFF
--- a/internlm/utils/gputest.py
+++ b/internlm/utils/gputest.py
@@ -39,7 +39,9 @@ def empty_cache_and_diag(batch_count, interval=50):
             with torch.no_grad():
                 timer_diagnosis()
                 bench_gpu()
-                bench_net()
+                # FIXME: Runtime benchmark diagnosis can easily cause the training process
+                # to exit due to NCCL errors.
+                # bench_net()
         # do empty_cache after the bench
         torch.cuda.empty_cache()
         # do garbage collection


### PR DESCRIPTION
Runtime benchmark diagnosis can easily cause the training process to exit due to NCCL errors. We will temporarily disable nccl diagnosis to avoid affecting user tasks. Need to fundamentally solve this problem in the future.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
