### PR TITLE
 feat(moe): enable shareed embedding weight for model training

### DIFF
--- a/configs/7B_MoE4_sft.py
+++ b/configs/7B_MoE4_sft.py
@@ -129,6 +129,7 @@ model = dict(
     checkpoint=False,  # The proportion of layers for activation aheckpointing, the optional value are True/False/[0-1]
     num_attention_heads=NUM_ATTENTION_HEAD,
     embed_split_hidden=True,
+    tie_embeddings_and_output_weights=False,
     vocab_size=VOCAB_SIZE,
     embed_grad_scale=1,
     parallel_output=True,

--- a/internlm/initialize/initialize_trainer.py
+++ b/internlm/initialize/initialize_trainer.py
@@ -70,8 +70,7 @@ def initialize_trainer(
 
     assert isinstance(optimizer, BaseOptimizer), "optimizer must be instance of BaseOptimizer"
 
-    # gradient handler, only support PipelineSharedModuleGradientHandler now
-    # TODO: can refactor code here
+    # gradient handler, support PipelineSharedModuleGradientHandler and EmbeddingSharedModuleGradientHandler now
     if gpc.is_using_pp():
         gpc.config.gradient_handler = [
             dict(type="PipelineSharedModuleGradientHandler"),

--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -293,6 +293,8 @@ def args_sanity_check():
             model._add_item("moe_use_residual", False)
         if "moe_gate_k" not in model:
             model._add_item("moe_gate_k", 2)
+        if "tie_embeddings_and_output_weights" not in model:
+            model._add_item("tie_embeddings_and_output_weights", False)
         assert not (
             gpc.config.model.num_experts > 1 and gpc.config.parallel.zero1.fsdp
         ), "FSDP does not support num_experts > 1"

--- a/internlm/model/linear.py
+++ b/internlm/model/linear.py
@@ -58,7 +58,7 @@ class ScaleColumnParallelLinear(nn.Linear):
         # If not, then the input is already gathered.
         if shared_weight is None:
             if self.weight is None:
-                raise RuntimeError("weight was not given in forward pass " "and skip_weight_allocation is True.")
+                raise RuntimeError("weight was not given in forward pass and skip_weight_allocation is True.")
             shared_weight = self.weight
         if self.weight_scale != 1:
             weight = shared_weight * self.weight_scale + (1 - self.weight_scale) * shared_weight.detach()
@@ -102,7 +102,7 @@ class RewardModelLinear(ScaleColumnParallelLinear):
         skip_weight_alloction: bool = False,
     ) -> None:
         # TODO have not use RewardModelLinear for now
-        assert not skip_weight_alloction, "shared weight not support here for now"
+        assert not skip_weight_alloction, "shared weight is not supported in RewardModelLinear for now"
 
         super().__init__(in_features, out_features, process_group, bias, device, dtype, weight_scale)
         torch.distributed.broadcast(self.weight, gpc.get_ranks_in_group(ParallelMode.TENSOR)[0], process_group)

--- a/internlm/model/modeling_moe.py
+++ b/internlm/model/modeling_moe.py
@@ -331,6 +331,7 @@ class PackedFlashInternLm1D(nn.Module):
         moe_use_rts (bool, optional): default=True, whether to use Random Token Selection.
         moe_use_residual (bool, optional): default=False, make this MoE layer a Residual MoE
                                           (https://arxiv.org/abs/2201.05596) layer.
+        tie_embeddings_and_output_weights: embedding and output layer share the same weight.
     """
 
     def __init__(
@@ -370,8 +371,14 @@ class PackedFlashInternLm1D(nn.Module):
         moe_drop_tokens: bool = True,
         moe_use_rts: bool = True,
         moe_use_residual: bool = False,
+        tie_embeddings_and_output_weights: bool = True,
     ):
         super().__init__()
+
+        assert not (
+            embed_split_hidden and tie_embeddings_and_output_weights
+        ), "shared embedding weights is not supported when embed_split_hidden is True."
+        self.tie_embeddings_and_output_weights = tie_embeddings_and_output_weights
 
         checkpoint_layer_num = int(num_layers * checkpoint)
 
@@ -446,12 +453,16 @@ class PackedFlashInternLm1D(nn.Module):
                 device=device,
                 dtype=dtype,
                 weight_scale=embed_grad_scale,
+                skip_weight_alloction=self.tie_embeddings_and_output_weights,
             )
             for _, param in self.head.named_parameters():
                 normal_(std=0.0052)(param)
                 if gpc.get_world_size(ParallelMode.TENSOR) > 1:
                     setattr(param, IS_TENSOR_PARALLEL, True)
         self.parallel_output = parallel_output
+
+        if self.tie_embeddings_and_output_weights:
+            self.initialize_word_embeddings(hidden_size, vocab_size, dtype, device)
 
     def forward(self, hidden_states=None, cu_seqlens=None, input_ids=None, indexes=None, inference_params=None):
         # attention_mask: compute attention on the places where the value is 1
@@ -491,11 +502,78 @@ class PackedFlashInternLm1D(nn.Module):
         if hasattr(self, "norm"):
             hidden_states = self.norm(hidden_states.float())
         if hasattr(self, "head"):
-            hidden_states = self.head(hidden_states)
+            if self.tie_embeddings_and_output_weights:
+                hidden_states = self.head(hidden_states, self.shared_embedding_weight())
+            else:
+                hidden_states = self.head(hidden_states)
 
         if not self.parallel_output:
             hidden_states = gather_forward_split_backward(hidden_states, ParallelMode.TENSOR, dim=-1)
         return hidden_states, moe_losses
+
+    def shared_embedding_weight(self):
+        if not self.tie_embeddings_and_output_weights:
+            raise Exception(
+                "shared_embedding_weight() called for last stage, but share_embeddings_and_output_weights is false"
+            )
+        assert isinstance(self.embedding, ParallelGPT2Embeddings)
+
+        return self.embedding.word_embeddings.weight
+
+    # TODO: refactor code
+    def initialize_word_embeddings(
+        self,
+        hidden_size: int = 768,
+        vocab_size: int = 50304,
+        dtype: torch.dtype = torch.float,
+        device: Optional[torch.device] = None,
+    ):
+        if not self.tie_embeddings_and_output_weights:
+            raise Exception("initialize_word_embeddings() was called but " "tie_embeddings_and_output_weights is false")
+
+        # This function just initializes the word embeddings in the final stage
+        # when we are using pipeline parallelism. Nothing to do if we aren't
+        # using pipeline parallelism.
+        if gpc.get_world_size(ParallelMode.PIPELINE) == 1:
+            return
+
+        # Parameters are shared between the word embeddings layers, and the
+        # heads at the end of the model. In a pipelined setup with more than
+        # one stage, the initial embedding layer and the head are on different
+        # workers, so we do the following:
+        # 1. Create a second copy of word_embeddings on the last stage, with
+        #    initial parameters of 0.0.
+        # 2. Do an all-reduce between the first and last stage to ensure that
+        #    the two copies of word_embeddings start off with the same
+        #    parameter values.
+        # 3. In the training loop, before an all-reduce between the grads of
+        #    the two word_embeddings layers to ensure that every applied weight
+        #    update is the same on both stages.
+        if gpc.is_pipeline_last_stage():
+            assert not gpc.is_pipeline_first_stage()
+            # set word_embeddings weights to 0 here, then copy first
+            # stage's weights using all_reduce below.
+            self.embedding = ParallelGPT2Embeddings(
+                embed_dim=hidden_size,
+                vocab_size=vocab_size,
+                max_position_embeddings=-1,
+                process_group=gpc.get_group(ParallelMode.TENSOR),
+                padding_idx=None,
+                sequence_parallel=gpc.config.parallel.sequence_parallel,
+                device=device,
+                dtype=dtype,
+            )
+            for _, param in self.embedding.named_parameters():
+                if gpc.get_world_size(ParallelMode.TENSOR) > 1:
+                    setattr(param, IS_TENSOR_PARALLEL, True)
+            self.shared_embedding_weight().data.fill_(0)
+
+        # Ensure that first and last stages have the same initial parameter
+        # values.
+        if gpc.is_pipeline_first_stage() or gpc.is_pipeline_last_stage():
+            torch.distributed.all_reduce(
+                self.shared_embedding_weight().data, group=gpc.get_group(ParallelMode.EMBEDDING)
+            )
 
 
 def _build_generic_model_1d(num_layers, num_chunks, device=torch.device("cuda"), **kwargs):
@@ -572,6 +650,7 @@ def build_model_with_moe_cfg(
     moe_drop_tokens: bool = True,
     moe_use_rts: bool = True,
     moe_use_residual: bool = False,
+    tie_embeddings_and_output_weights=False,
 ):
     """
     Build model with config.
@@ -613,6 +692,7 @@ def build_model_with_moe_cfg(
         moe_use_rts (bool, optional): default=True, whether to use Random Token Selection.
         moe_use_residual (bool, optional): default=False, make this MoE layer a Residual MoE
                                            (https://arxiv.org/abs/2201.05596) layer.
+        tie_embeddings_and_output_weights: embedding and output layer share the same weight.
     """
 
     cfg = dict(
@@ -646,6 +726,7 @@ def build_model_with_moe_cfg(
         moe_drop_tokens=moe_drop_tokens,
         moe_use_rts=moe_use_rts,
         moe_use_residual=moe_use_residual,
+        tie_embeddings_and_output_weights=tie_embeddings_and_output_weights,
     )
 
     return _build_generic_model_1d(num_layers=num_layers, num_chunks=num_chunks, **cfg)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR enables the feature that the embedding and head(output) layer share the same weight. In such case, the output layer will use embedding's weight to perform forward pass. 
With pipeline, since the embedding and head(output) layer are not located in the same device, we create the embedding layer copy in the last stage and always sync grad with the embedding layer in the first stage.

## Modification

1. configs/7B_MoE4_sft.py: add share embedding weight switch. Note this can not be enabled when embed_split_hidden is True since the partition dimensions are different.
2. internlm/core/context/process_group_initializer.py: create new parallel mode "embedding" to sync grad in the first and last pipline stage
3. internlm/core/gradient_handler.py: create embedding gradient handler when pipeline and share embedding weight are both enabled
4. internlm/initialize/initialize_trainer.py: register embedding gradient handler
5. internlm/model/linear.py: perform forward pass with embedding weight when  share embedding weight is enabled
6. internlm/model/modeling_moe.py: 
         * create embedding in the last stage when pipeline and share embedding weight are both enabled
         * pass  share embedding weight to head layer when perform forward pass



## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
