### PR TITLE
 fix(moe): remove norm&gate force sync

### DIFF
--- a/internlm/model/modeling_moe.py
+++ b/internlm/model/modeling_moe.py
@@ -127,11 +127,6 @@ class PackedFlashBaseLayer1D(nn.Module):
         else:
             self.norm1 = nn.LayerNorm(hidden_size, eps=layer_norm_epsilon)
             self.norm2 = nn.LayerNorm(hidden_size, eps=layer_norm_epsilon)
-
-        for param in self.norm1.parameters():
-            param.is_norm = True
-        for param in self.norm2.parameters():
-            param.is_norm = True
         set_fp32_attr_to_module(self.norm1)
         set_fp32_attr_to_module(self.norm2)
 

--- a/internlm/model/utils.py
+++ b/internlm/model/utils.py
@@ -215,18 +215,6 @@ def is_moe_param(param: torch.Tensor) -> bool:
     return False
 
 
-def is_gate_param(param: torch.Tensor) -> bool:
-    if hasattr(param, "is_gate") and param.is_gate:
-        return True
-    return False
-
-
-def is_norm_param(param: torch.Tensor) -> bool:
-    if hasattr(param, "is_norm") and param.is_norm:
-        return True
-    return False
-
-
 def Silu(w1_o, w2_o):
     return F.silu(w1_o) * w2_o
 

--- a/internlm/moe/sharded_moe.py
+++ b/internlm/moe/sharded_moe.py
@@ -352,9 +352,6 @@ class TopKGate(Module):
         self.drop_tokens = drop_tokens
         self.use_rts = use_rts
 
-        for param in self.wg.parameters():
-            param.is_gate = True
-
     def forward(
         self, inputs: torch.Tensor, used_token: torch.Tensor = None
     ) -> Tuple[Tensor, Tensor, Tensor]:  # type: ignore

--- a/internlm/solver/optimizer/hybrid_zero_optim.py
+++ b/internlm/solver/optimizer/hybrid_zero_optim.py
@@ -710,6 +710,9 @@ class HybridZeroOptimizer(BaseOptimizer):
         with torch.cuda.stream(self._comm_bcast_stream):
             self.broadcast_params()
 
+        if not self._overlap_sync_param:
+            torch.cuda.synchronize()
+
         timer("step").stop()
 
         # update gradients may not be needed here, because the sync_params function is used in initialization,

--- a/internlm/solver/optimizer/hybrid_zero_optim.py
+++ b/internlm/solver/optimizer/hybrid_zero_optim.py
@@ -274,12 +274,6 @@ class HybridZeroOptimizer(BaseOptimizer):
     def _is_moe_group(self, param_group):
         return "moe" in param_group.keys() and param_group["moe"]
 
-    def _is_norm_group(self, param_group):
-        return "norm" in param_group.keys() and param_group["norm"]
-
-    def _is_gate_group(self, param_group):
-        return "gate" in param_group.keys() and param_group["gate"]
-
     # TODO check expert dp is correct when enable moe and overlap both
     def _attach_reduction_hook(self):
         # we iterate over the fp16 params

--- a/internlm/solver/optimizer/hybrid_zero_optim.py
+++ b/internlm/solver/optimizer/hybrid_zero_optim.py
@@ -657,16 +657,16 @@ class HybridZeroOptimizer(BaseOptimizer):
 
             # Parameters shared within a TP group, such as norm and moe gate, have precision inconsistency in gradients.
             # Therefore, it is recommended to synchronize gradients within the TP group to eliminate accumulated errors.
-            is_tp_sync_groups = (
-                self._is_norm_group(self.optim.param_groups[group_id]),
-                self._is_gate_group(self.optim.param_groups[group_id]),
-            )
-            if any(is_tp_sync_groups):
-                dist.all_reduce(
-                    flat_fp32_avg_grads,
-                    op=dist.ReduceOp.AVG,
-                    group=gpc.get_group(ParallelMode.TENSOR),
-                )
+            # is_tp_sync_groups = (
+            #     self._is_norm_group(self.optim.param_groups[group_id]),
+            #     self._is_gate_group(self.optim.param_groups[group_id]),
+            # )
+            # if any(is_tp_sync_groups):
+            #     dist.all_reduce(
+            #         flat_fp32_avg_grads,
+            #         op=dist.ReduceOp.AVG,
+            #         group=gpc.get_group(ParallelMode.TENSOR),
+            #     )
 
             single_grad_partition_groups.append(flat_fp32_avg_grads)
             device = self._fp32_flat_param_groups_of_current_rank[group_id].device

--- a/internlm/solver/optimizer/utils.py
+++ b/internlm/solver/optimizer/utils.py
@@ -252,16 +252,6 @@ def reduce_grads(gradients, parameters, fine_grained=False):
     return parallel_grads
 
 
-def reduce_moe_norm(total_norm):
-    pg = gpc.get_group(ParallelMode.EXPERT)
-    scaled_norm = total_norm * 1.0 / float(gpc.get_world_size(ParallelMode.DATA))
-    scaled_norm_tensor = torch.tensor(scaled_norm, device=get_current_device(), dtype=torch.float)
-    dist.all_reduce(scaled_norm_tensor, group=pg)
-    total_norm = scaled_norm_tensor.item()
-
-    return total_norm
-
-
 def compute_norm(
     gradients,
     parameters,
@@ -344,7 +334,11 @@ def compute_norm(
     # Need to allreduce(avg) the norms across different ranks because moe params will not be synced during allreduce
     # model and zero have been reduced!!!
     if zero_mode == ParallelMode.EXPERT_DATA:
-        total_norm = reduce_moe_norm(total_norm)
+        pg = gpc.get_group(ParallelMode.EXPERT)
+        scaled_norm = total_norm * 1.0 / float(gpc.get_world_size(ParallelMode.DATA))
+        scaled_norm_tensor = torch.tensor(scaled_norm, device=get_current_device(), dtype=torch.float)
+        dist.all_reduce(scaled_norm_tensor, group=pg)
+        total_norm = scaled_norm_tensor.item()
 
     # Scale.
     if total_norm == float("inf") or total_norm == -float("inf"):
@@ -433,7 +427,12 @@ def compute_param_norm(
 
     # moe
     if zero_mode == ParallelMode.EXPERT_DATA:
-        total_param_norms = reduce_moe_norm(total_param_norms)
+        pg = gpc.get_group(ParallelMode.EXPERT)
+        scaled_param_norm = torch.cuda.FloatTensor(list(total_param_norms.values()), device=get_current_device())
+        scaled_param_norm = scaled_param_norm / float(gpc.get_world_size(ParallelMode.EXPERT))
+        dist.all_reduce(scaled_param_norm, group=pg)
+        for i, param_name in enumerate(total_param_norms.keys()):
+            total_param_norms[param_name] = scaled_param_norm[i].item()
 
     # scale
     for param_name, param_norm in total_param_norms.items():

--- a/internlm/train/utils.py
+++ b/internlm/train/utils.py
@@ -39,7 +39,7 @@ def split_params_into_different_groups_for_optimizer(param_groups: Tuple[Dict]) 
     # create new groups for fp32, norm, moe gate and moe expert
     new_groups = {}
     new_groups["fp32"] = {"name": "fp32", "params": [], "dp_mode": ParallelMode.DATA}
-    if gpc.config.model.get("num_experts", 0) > 1:
+    if gpc.config.model.get("num_experts", 1) > 1:
         for key in gpc.expert_parallel_group_names:
             new_groups[key] = {"name": key, "moe": True, "params": [], "dp_mode": ParallelMode.EXPERT_DATA}
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

since calling wait() does not guarantee completing the entire broadcast process, it may cause some problems. Also see:
[1] [synchronous-and-asynchronous-collective-operations in pytorch](https://pytorch.org/docs/stable/distributed.html#synchronous-and-asynchronous-collective-operations)
[2] [Question about wait() for asynchronous collective operations with NCCL](https://github.com/pytorch/pytorch/issues/68112)
[3] [Does the NCCL operation use the default stream as other computations?](https://github.com/pytorch/pytorch/issues/60511)
[4] [wait() does not block the default stream for NCCL's asynchronous P2P operations](https://github.com/pytorch/pytorch/issues/68866)

After fixing above bug in https://github.com/InternLM/InternLM/pull/453, the training can be normal. So this PR removes the force sync of norm and gate param.

![企业微信截图_16988082602099](https://github.com/InternLM/InternLM/assets/11952914/7659032f-9d98-4aa0-a920-87dae05c01e9)



## Modification

internlm/solver/optimizer/hybrid_zero_optim.py: remove gate & norm param sync
internlm/solver/train/utils.py: remove gate & norm group
internlm/solver/optimizer/utils.py: refactor code for moe norm computing. 

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
