### PR TITLE
Fix(trainer):  Save tensorboard path on petrelfs for volc

### DIFF
--- a/internlm/core/trainer.py
+++ b/internlm/core/trainer.py
@@ -4,6 +4,7 @@
 # adopted from https://github.com/hpcaitech/ColossalAI/blob/main/colossalai/engine
 
 import json
+import os
 from collections import deque
 from typing import Iterable, Optional
 
@@ -120,13 +121,17 @@ class TrainState:
         self.resume_tb_folder = other_stuffs.get("tensorboard_folder", None)
 
     def state_dict(self):
+        if os.environ.get("CLUSTER_NAME") == "volc" and os.environ.get("petrelfs_tb_path") is not None:
+            tensorboard_folder = os.path.join(os.environ["petrelfs_tb_path"], os.environ["MLP_TASK_ID"])
+        else:
+            tensorboard_folder = self.tensorboard_folder
         return {
             "batch_count": self.batch_count,
             "num_consumed_samples_in_epoch": self.num_consumed_samples_in_epoch,
             "num_consumed_tokens": self.num_consumed_tokens,
             "inf_nan_skip_batches": self.inf_nan_skip_batches,
             "step_count": self.step_count,
-            "tensorboard_folder": self.tensorboard_folder,
+            "tensorboard_folder": tensorboard_folder,
         }
 
 


### PR DESCRIPTION
## Motivation

When the volcano cloud model loads ckpt for continued training, there will be a tensorboard segmentation problem. The reason is that the tb path of the volcano itself is special.

## Modification

Sdd tensorboard path on petrelfs for volc.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
