### PR TITLE
fix(alert): send exception to light monitor only if the server is available

### DIFF
--- a/internlm/monitor/monitor.py
+++ b/internlm/monitor/monitor.py
@@ -155,7 +155,11 @@ class MonitorManager(metaclass=SingletonMeta):
         format_trace = ""
         for line in filtered_trace:
             format_trace += "\n" + line
-        if self.send_exception:
+        if (
+            self.send_exception
+            and gpc.config.monitor.alert.get("enable_feishu_alert", False)
+            and gpc.config.monitor.alert.get("light_monitor_address", None)
+        ):
             self.send_exception(format_trace, gpc.get_global_rank())
         send_alert_message(
             address=alert_address,
@@ -169,7 +173,11 @@ class MonitorManager(metaclass=SingletonMeta):
             print("receive frame: ", frame)
             print("receive signal: ", sys_signal)
             message = f"Process received signal {signal} and exited."
-            if self.send_exception:
+            if (
+                self.send_exception
+                and gpc.config.monitor.alert.get("enable_feishu_alert", False)
+                and gpc.config.monitor.alert.get("light_monitor_address", None)
+            ):
                 self.send_exception(message, gpc.get_global_rank())
             send_alert_message(
                 address=alert_address,


### PR DESCRIPTION
## Motivation

修复在未启用轻量监控时，发送execption的问题。

![企业微信截图_16987334957528](https://github.com/InternLM/InternLM/assets/44927264/b4ba3d1f-b8c2-4a3e-97b7-3b644fd2d6c2)


## Modification

`internlm/monitor/monitor.py`




