### PR TITLE
feat(tools): support dynamic ntk rope in transformers

### DIFF
--- a/tools/transformers/internlm_model/configuration_internlm.py
+++ b/tools/transformers/internlm_model/configuration_internlm.py
@@ -19,9 +19,8 @@
 # limitations under the License.
 """ InternLM model configuration"""
 
-from transformers.utils import logging
 from transformers.configuration_utils import PretrainedConfig
-
+from transformers.utils import logging
 
 logger = logging.get_logger(__name__)
 
@@ -30,9 +29,9 @@ INTERNLM_PRETRAINED_CONFIG_ARCHIVE_MAP = {}
 
 class InternLMConfig(PretrainedConfig):
     r"""
-    This is the configuration class to store the configuration of a [`InternLMModel`]. It is used to instantiate an InternLM
-    model according to the specified arguments, defining the model architecture. Instantiating a configuration with the
-    defaults will yield a similar configuration to that of the InternLM-7B.
+    This is the configuration class to store the configuration of a [`InternLMModel`]. It is used to instantiate
+    an InternLM model according to the specified arguments, defining the model architecture. Instantiating a
+    configuration with the defaults will yield a similar configuration to that of the InternLM-7B.
 
     Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
     documentation from [`PretrainedConfig`] for more information.
@@ -81,7 +80,7 @@ class InternLMConfig(PretrainedConfig):
     model_type = "internlm"
     _auto_class = "AutoConfig"
 
-    def __init__(
+    def __init__(  # pylint: disable=W0102
         self,
         vocab_size=103168,
         hidden_size=4096,
@@ -98,6 +97,7 @@ class InternLMConfig(PretrainedConfig):
         eos_token_id=2,
         tie_word_embeddings=False,
         bias=True,
+        rotary={"base": 10000, "type": "dynamic"},  # pylint: disable=W0102
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -111,6 +111,7 @@ class InternLMConfig(PretrainedConfig):
         self.rms_norm_eps = rms_norm_eps
         self.use_cache = use_cache
         self.bias = bias
+        self.rotary = rotary
         super().__init__(
             pad_token_id=pad_token_id,
             bos_token_id=bos_token_id,

--- a/tools/transformers/internlm_model/modeling_internlm.py
+++ b/tools/transformers/internlm_model/modeling_internlm.py
@@ -105,6 +105,14 @@ class InternLMRMSNorm(nn.Module):
 
 
 class InternLMRotaryEmbedding(torch.nn.Module):
+    """Implement InternLM's rotary embedding.
+
+    Args:
+        dim (int): Characteristic dimension of each self-attentional head.
+        max_position_embeddings (int, optional): Model's training length. Defaults to 2048.
+        base (int, optional): The rotation position encodes the rotation Angle base number. Defaults to 10000.
+        device (Any, optional): Running device. Defaults to None.
+    """
     def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None):
         super().__init__()
         inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float().to(device) / dim))
@@ -137,7 +145,14 @@ class InternLMRotaryEmbedding(torch.nn.Module):
 
 
 class InternLMDynamicNTKScalingRotaryEmbedding(torch.nn.Module):
-    """Implement dynamic ntk rope.
+    """Implement InternLM's DyanmicNTK extrapolation method, thereby broadening the model support context to 16K.
+
+    Args:
+        dim (int): Characteristic dimension of each self-attentional head.
+        max_position_embeddings (int, optional): Model's training length. Defaults to 2048.
+        base (int, optional): The rotation position encodes the rotation Angle base number. Defaults to 10000.
+        device (Any, optional): Running device. Defaults to None.
+        scaling_factor (float, optional): NTK method extrapolation coefficient. Defaults to 1.0.
     """
 
     def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None, scaling_factor=1.0):

--- a/tools/transformers/internlm_model/modeling_internlm.py
+++ b/tools/transformers/internlm_model/modeling_internlm.py
@@ -137,14 +137,7 @@ class InternLMRotaryEmbedding(torch.nn.Module):
 
 
 class InternLMDynamicNTKScalingRotaryEmbedding(torch.nn.Module):
-    """实现dynamic ntk rope；
-
-    需要保证：
-    1. 长度小于 seq len 时能够不断地复用；
-    2. 长度超过 seq len 时，每一个 新的token，都需要一个新的base；
-
-    Args:
-        InternLMRotaryEmbedding (_type_): _description_
+    """Implement dynamic ntk rope.
     """
 
     def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None, scaling_factor=1.0):

--- a/tools/transformers/internlm_model/modeling_internlm.py
+++ b/tools/transformers/internlm_model/modeling_internlm.py
@@ -19,25 +19,35 @@
 # limitations under the License.
 """ PyTorch InternLM model."""
 import math
+import queue
+import threading
 from typing import List, Optional, Tuple, Union
-import threading, queue
 
 import torch
 import torch.utils.checkpoint
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
-
 from transformers.activations import ACT2FN
-from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast, SequenceClassifierOutputWithPast
-from transformers.modeling_utils import PreTrainedModel
 from transformers.generation.streamers import BaseStreamer
-from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward, logging, replace_return_docstrings
-from .configuration_internlm import InternLMConfig
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+    SequenceClassifierOutputWithPast,
+)
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import (
+    add_start_docstrings,
+    add_start_docstrings_to_model_forward,
+    logging,
+    replace_return_docstrings,
+)
 
+from .configuration_internlm import InternLMConfig
 
 logger = logging.get_logger(__name__)
 
 _CONFIG_FOR_DOC = "InternLMConfig"
+
 
 # Copied from transformers.models.bart.modeling_bart._make_causal_mask
 def _make_causal_mask(
@@ -73,6 +83,8 @@ def _expand_mask(mask: torch.Tensor, dtype: torch.dtype, tgt_len: Optional[int] 
 
 
 class InternLMRMSNorm(nn.Module):
+    """RMSNorm implemention."""
+
     def __init__(self, hidden_size, eps=1e-6):
         """
         InternLMRMSNorm is equivalent to T5LayerNorm
@@ -134,6 +146,7 @@ class InternLMDynamicNTKScalingRotaryEmbedding(torch.nn.Module):
     Args:
         InternLMRotaryEmbedding (_type_): _description_
     """
+
     def __init__(self, dim, max_position_embeddings=2048, base=10000, device=None, scaling_factor=1.0):
         super().__init__()
         inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float().to(device) / dim))
@@ -151,7 +164,7 @@ class InternLMDynamicNTKScalingRotaryEmbedding(torch.nn.Module):
         emb = torch.cat((freqs, freqs), dim=-1)
         self.register_buffer("cos_cached", emb.cos()[None, None, :, :], persistent=False)
         self.register_buffer("sin_cached", emb.sin()[None, None, :, :], persistent=False)
-    
+
     def _update_cached(self, x, seq_len=None):
         self.max_seq_len_cached = max(seq_len, self.max_position_embeddings)
         if seq_len > self.max_position_embeddings:
@@ -166,7 +179,6 @@ class InternLMDynamicNTKScalingRotaryEmbedding(torch.nn.Module):
         emb = torch.cat((freqs, freqs), dim=-1)
         self.register_buffer("cos_cached", emb.cos()[None, None, :, :], persistent=False)
         self.register_buffer("sin_cached", emb.sin()[None, None, :, :], persistent=False)
-    
 
     def forward(self, x, seq_len=None):
         # x: [bs, num_attention_heads, seq_len, head_size]
@@ -177,11 +189,12 @@ class InternLMDynamicNTKScalingRotaryEmbedding(torch.nn.Module):
                 self._update_cached(x, seq_len)
         else:
             self._update_cached(x, seq_len)
-    
+
         return (
             self.cos_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
             self.sin_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
         )
+
 
 def rotate_half(x):
     """Rotates half the hidden dims of the input."""
@@ -251,20 +264,19 @@ class InternLMAttention(nn.Module):
     def _init_rope(self):
         if self.config.rotary["type"] == "origin":
             self.rotary_emb = InternLMRotaryEmbedding(
-                self.head_dim, 
+                self.head_dim,
                 max_position_embeddings=self.max_position_embeddings,
                 base=self.config.rotary["base"],
             )
         elif self.config.rotary["type"] == "dynamic":
             self.rotary_emb = InternLMDynamicNTKScalingRotaryEmbedding(
-                self.head_dim, 
+                self.head_dim,
                 max_position_embeddings=self.max_position_embeddings,
                 base=self.config.rotary["base"],
-                scaling_factor=self.config.rotary.get("scaling_factor", 1.0)
+                scaling_factor=self.config.rotary.get("scaling_factor", 1.0),
             )
         else:
             raise ValueError("Currently we only support rotary embedding's type being one of ('origin', 'dynamic').")
-
         return self.rotary_emb
 
     def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
@@ -470,7 +482,8 @@ INTERNLM_INPUTS_DOCSTRING = r"""
             Indices of positions of each input sequence tokens in the position embeddings. Selected in the range `[0,
             config.n_positions - 1]`.
             [What are position IDs?](../glossary#position-ids)
-        past_key_values (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+        past_key_values (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `use_cache=True` is passed or
+            when `config.use_cache=True`):
             Tuple of `tuple(torch.FloatTensor)` of length `config.n_layers`, with each tuple having 2 tensors of shape
             `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and 2 additional tensors of shape
             `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
@@ -507,6 +520,7 @@ class InternLMModel(InternLMPreTrainedModel):
     Args:
         config: InternLMConfig
     """
+
     _auto_class = "AutoModel"
 
     def __init__(self, config: InternLMConfig):
@@ -829,50 +843,56 @@ class InternLMForCausalLM(InternLMPreTrainedModel):
         for layer_past in past_key_values:
             reordered_past += (tuple(past_state.index_select(0, beam_idx) for past_state in layer_past),)
         return reordered_past
-    
+
     def build_inputs(self, tokenizer, query: str, history: List[Tuple[str, str]] = []):
         prompt = ""
         for record in history:
             prompt += f"""<|User|>:{record[0]}<eoh>\n<|Bot|>:{record[1]}<eoa>\n"""
         prompt += f"""<|User|>:{query}<eoh>\n<|Bot|>:"""
         return tokenizer([prompt], return_tensors="pt")
-    
+
     @torch.no_grad()
-    def chat(self, 
-             tokenizer, 
-             query: str,
-             history: List[Tuple[str, str]] = [], 
-             streamer: Optional[BaseStreamer] = None,
-             max_new_tokens: int = 1024,
-             do_sample: bool = True,
-             temperature: float = 0.8,
-             top_p: float = 0.8,
-             **kwargs):
+    def chat(
+        self,
+        tokenizer,
+        query: str,
+        history: List[Tuple[str, str]] = [],
+        streamer: Optional[BaseStreamer] = None,
+        max_new_tokens: int = 1024,
+        do_sample: bool = True,
+        temperature: float = 0.8,
+        top_p: float = 0.8,
+        **kwargs,
+    ):
         inputs = self.build_inputs(tokenizer, query, history)
         inputs = {k: v.to(self.device) for k, v in inputs.items() if torch.is_tensor(v)}
-        outputs = self.generate(**inputs, 
-                                streamer=streamer, 
-                                max_new_tokens=max_new_tokens, 
-                                do_sample=do_sample, 
-                                temperature=temperature, 
-                                top_p=top_p, 
-                                **kwargs)
-        outputs = outputs[0].cpu().tolist()[len(inputs["input_ids"][0]):]
+        outputs = self.generate(
+            **inputs,
+            streamer=streamer,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_p=top_p,
+            **kwargs,
+        )
+        outputs = outputs[0].cpu().tolist()[len(inputs["input_ids"][0]) :]
         response = tokenizer.decode(outputs, skip_special_tokens=True)
         response = response.split("<eoa>")[0]
         history = history + [(query, response)]
         return response, history
-    
+
     @torch.no_grad()
-    def stream_chat(self, 
-                    tokenizer,
-                    query: str,
-                    history: List[Tuple[str, str]] = [], 
-                    max_new_tokens: int = 1024,
-                    do_sample: bool = True,
-                    temperature: float = 0.8,
-                    top_p: float = 0.8,
-                    **kwargs):
+    def stream_chat(
+        self,
+        tokenizer,
+        query: str,
+        history: List[Tuple[str, str]] = [],
+        max_new_tokens: int = 1024,
+        do_sample: bool = True,
+        temperature: float = 0.8,
+        top_p: float = 0.8,
+        **kwargs,
+    ):
         """
         Return a generator in format: (response, history)
         Eg.
@@ -918,12 +938,12 @@ class InternLMForCausalLM(InternLMPreTrainedModel):
                 tokenizer=tokenizer,
                 query=query,
                 streamer=ChatStreamer(tokenizer=tokenizer),
-                history=history, 
+                history=history,
                 max_new_tokens=max_new_tokens,
                 do_sample=do_sample,
                 temperature=temperature,
                 top_p=top_p,
-                **kwargs
+                **kwargs,
             )
 
         def consumer():


### PR DESCRIPTION

## Motivation

Support using dynamic ntk rope in transformers.

## Modification

Mainly modified `InternLM/tools/transformers/internlm_model/modeling_internlm.py`.

Add a new rope class named `InternLMDynamicNTKScalingRotaryEmbedding`.


## Use cases (Optional)

This feature is enabled by default because the default behavior is the same as the original rope behavior, but when the input or generation length exceeds max_position_embeddings, dynamic ntk's generation results will be better.

User can change the value in the `config.json` to change this behaviour.
For example, change config['rotary']['type'] to `origin`.

![image](https://github.com/InternLM/InternLM/assets/46778265/7dc8a3a7-56ab-409f-8971-48f0d83219e8)




