### PR TITLE
feat(tools): support origin internlm architecture in web_demo

### DIFF
--- a/README-ja-JP.md
+++ b/README-ja-JP.md
@@ -133,6 +133,12 @@ streamlit run web_demo.py
 
 ![demo](https://github.com/InternLM/InternLM/assets/9102141/11b60ee0-47e4-42c0-8278-3051b2f17fe4)
 
+`web_demo_internlm.py` を使用して、InternLM 形式のモデルと直接対話できるようになりました。
+まず、モデルの重みを InternLM 形式でダウンロードし、`web_demo_internlm.py` の `ckpt_dir` を置き換えてください。 次のコマンドを実行して対話します。
+```python
+torchrun --master_port 12331 --nnodes=1 --node_rank=0 --nproc_per_node=1 -m streamlit run web_demo_internlm.py
+```
+
 ### デプロイ
 
 [LMDeploy](https://github.com/InternLM/LMDeploy) を使って、InternLM をワンクリックでデプロイする。

--- a/README-zh-Hans.md
+++ b/README-zh-Hans.md
@@ -44,7 +44,7 @@ InternLM 是一个开源的轻量级训练框架，旨在支持大模型训练�
 
 ## 更新
 
-[20230920] InternLM-20B 已发布，包括基础版和对话版。  
+[20230920] InternLM-20B 已发布，包括基础版和对话版。
 [20230822] InternLM-7B-Chat v1.1 已发布，增加了代码解释器和函数调用能力。您可以使用 [Lagent](https://github.com/InternLM/lagent) 进行尝试。
 
 
@@ -62,13 +62,13 @@ InternLM 是一个开源的轻量级训练框架，旨在支持大模型训练�
 | **InternLM Chat 7B 8k**   | [🤗internlm/internlm-chat-7b-8k](https://huggingface.co/internlm/internlm-chat-7b-8k)     | [<img src="./doc/imgs/modelscope_logo.png" width="20px" /> Shanghai_AI_Laboratory/internlm-chat-7b-8k](https://modelscope.cn/models/Shanghai_AI_Laboratory/internlm-chat-7b-8k/summary)     | [![Open in OpenXLab](https://cdn-static.openxlab.org.cn/header/openxlab_models.svg)](https://openxlab.org.cn/models/detail/OpenLMLab/InternLM-chat-7b-8k)   | 2023-07-06   |
 
 
-<details> 
+<details>
 <summary> InternLM-20B </summary>
 
 #### 简介
-InternLM-20B 在超过 **2.3T** Tokens 包含高质量英文、中文和代码的数据上进行预训练，其中 Chat 版本还经过了 SFT 和 RLHF 训练，使其能够更好、更安全地满足用户的需求。  
+InternLM-20B 在超过 **2.3T** Tokens 包含高质量英文、中文和代码的数据上进行预训练，其中 Chat 版本还经过了 SFT 和 RLHF 训练，使其能够更好、更安全地满足用户的需求。
 
-InternLM 20B 在模型结构上选择了深结构，InternLM-20B 的层数设定为60层，超过常规7B和13B模型所使用的32层或者40层。在参数受限的情况下，提高层数有利于提高模型的综合能力。此外，相较于InternLM-7B，InternLM-20B使用的预训练数据经过了更高质量的清洗，并补充了高知识密度和用于强化理解和推理能力的训练数据。因此，它在理解能力、推理能力、数学能力、编程能力等考验语言模型技术水平的方面都得到了显著提升。总体而言，InternLM-20B具有以下的特点： 
+InternLM 20B 在模型结构上选择了深结构，InternLM-20B 的层数设定为60层，超过常规7B和13B模型所使用的32层或者40层。在参数受限的情况下，提高层数有利于提高模型的综合能力。此外，相较于InternLM-7B，InternLM-20B使用的预训练数据经过了更高质量的清洗，并补充了高知识密度和用于强化理解和推理能力的训练数据。因此，它在理解能力、推理能力、数学能力、编程能力等考验语言模型技术水平的方面都得到了显著提升。总体而言，InternLM-20B具有以下的特点：
 - 优异的综合性能
 - 很强的工具调用功能
 - 支持16k语境长度（通过推理时外推）
@@ -117,7 +117,7 @@ InternLM 20B 在模型结构上选择了深结构，InternLM-20B 的层数设定
 </details>
 
 
-<details> 
+<details>
 <summary> InternLM-7B </summary>
 
 #### 模型更新
@@ -194,7 +194,7 @@ for response, history in model.stream_chat(tokenizer, "你好", history=[]):
     length = len(response)
 ```
 
-### 通过 ModelScope 加载 
+### 通过 ModelScope 加载
 
 通过以下的代码从 ModelScope 加载 InternLM 模型 （可修改模型名称替换不同的模型）
 
@@ -225,6 +225,12 @@ streamlit run web_demo.py
 效果如下
 
 ![效果](https://github.com/InternLM/InternLM/assets/9102141/11b60ee0-47e4-42c0-8278-3051b2f17fe4)
+
+现在您可以使用 `web_demo_internlm.py` 直接与 InternLM 格式的模型进行交互。
+首先请下载 InternLM 格式的模型权重，然后替换 `web_demo_internlm.py` 中的 `ckpt_dir`。运行以下命令进行交互：
+````bash
+torchrun --master_port 12331 --nnodes=1 --node_rank=0 --nproc_per_node=1 -m streamlit run web_demo_internlm.py
+````
 
 ### 基于InternLM高性能部署
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Based on the InternLM training framework, we have released two open-sourced pret
 
 ## News
 
-[20230920] InternLM-20B is released with base and chat versions.  
+[20230920] InternLM-20B is released with base and chat versions.
 [20230822] InternLM-7B-Chat v1.1 is released with code interpreter and function calling capability. You can try it with [Lagent](https://github.com/InternLM/lagent).
 
 
 ## Model Zoo
 
-Our models are released in three platforms: Transformers, ModelScope and OpenXLab.  
+Our models are released in three platforms: Transformers, ModelScope and OpenXLab.
 
 | Model                     | Transformers                                                               | ModelScope                                                                                                                          | OpenXLab                                                                                                                                      | Release Date |
 |---------------------------|------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
@@ -113,7 +113,7 @@ Overall, InternLM-20B comprehensively outperforms open-source models in the 13B 
 </details>
 
 
-<details> 
+<details>
 <summary> InternLM-7B </summary>
 
 #### News
@@ -221,6 +221,13 @@ streamlit run web_demo.py
 The effect is as follows
 
 ![demo](https://github.com/InternLM/InternLM/assets/9102141/11b60ee0-47e4-42c0-8278-3051b2f17fe4)
+
+Now you can interact with models directly in InternLM format using `web_demo_internlm.py`.
+First, please download the model weights in InternLM format, and then replace `ckpt_dir` in `web_demo_internlm.py`. Start by running the following command:
+```bash
+torchrun --master_port 12331 --nnodes=1 --node_rank=0 --nproc_per_node=1 -m streamlit run web_demo_internlm.py
+```
+
 
 ### Deployment
 

--- a/internlm/apis/inference.py
+++ b/internlm/apis/inference.py
@@ -407,12 +407,10 @@ def _streaming_no_beam_search_generate(
             bos_pos = torch.where(bos_sum.eq(bos_sum[:, -1:]), 0, 1)
             to_atten_x = bos_pos[:, :, None]
             to_atten_y = bos_pos[:, None, :]
-            # attention_mask = torch.einsum('bno,bom->bnm', to_atten_x, to_atten_y).eq(1)
         else:
             bos_pos = torch.where(token_ids.eq(bos_token_id), 1, 0)
             to_atten_x = bos_pos[:, :, None]
             to_atten_y = bos_pos[:, None, :]
-            # attention_mask = torch.einsum('bno,bom->bnm', to_atten_x, to_atten_y).eq(1)
         attention_mask = torch.logical_or(to_atten_x, to_atten_y).eq(1)
         inference_params.attention_mask = attention_mask
         scores = decoder(**{"input_ids": token_ids[:, -1:], "inference_params": inference_params})

--- a/internlm/apis/inference.py
+++ b/internlm/apis/inference.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
+from typing import List, Tuple
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -66,11 +68,21 @@ class SequenceGenerator:
     Sequence Generator.
     """
 
-    def __init__(self, decoder, eos_token_id, pad_token_id, bos_token_id):
+    def __init__(
+        self,
+        decoder,
+        eos_token_id,
+        pad_token_id,
+        bos_token_id,
+        additional_eos_token_list=None,
+        add_eos_when_return=False,
+    ):
         self.decoder = decoder
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id
         self.bos_token_id = bos_token_id
+        self.additional_eos_token_list = additional_eos_token_list
+        self.add_eos_when_return = add_eos_when_return
 
     @torch.no_grad()
     def generate(
@@ -85,7 +97,6 @@ class SequenceGenerator:
         top_p: float = 1.0,
         repetition_penalty: float = 1,
         length_penalty: float = 1.0,
-        streaming=False
     ):
         """
         Args:
@@ -115,12 +126,13 @@ class SequenceGenerator:
                 top_k=top_k,
                 top_p=top_p,
                 eos_token_id=self.eos_token_id,  # the ending token id
+                additional_eos_token_list=self.additional_eos_token_list,
+                add_eos_when_return=self.add_eos_when_return,
                 pad_token_id=self.pad_token_id,
                 repetition_penalty=repetition_penalty,  # the penalty degree for repetition tokens
                 length_penalty=length_penalty,  # the penalty for length. if it > 1, then encourages long sequence.
                 # Otherwise, encourages short sequence.
                 bos_token_id=self.bos_token_id,
-                streaming=streaming
             )
         else:
             return greedy_generate(
@@ -130,11 +142,59 @@ class SequenceGenerator:
                 num_beams=num_beams,
                 num_return_sequences=num_return_sequences,
                 eos_token_id=self.eos_token_id,
+                additional_eos_token_list=self.additional_eos_token_list,
+                add_eos_when_return=self.add_eos_when_return,
                 pad_token_id=self.pad_token_id,
                 repetition_penalty=repetition_penalty,
                 length_penalty=length_penalty,
                 bos_token_id=self.bos_token_id,
-                streaming=streaming
+            )
+
+    @torch.no_grad()
+    def streaming_generate(
+        self,
+        tokens: "torch.LongTensor" = None,
+        max_length: int = 20,
+        do_sample: bool = True,
+        temperature: float = 1.0,
+        top_k: int = 50,
+        top_p: float = 1.0,
+        repetition_penalty: float = 1,
+        length_penalty: float = 1.0,
+    ):
+        if do_sample:
+            yield from _streaming_no_beam_search_generate(
+                self.decoder,
+                tokens=tokens,
+                max_length=max_length,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                eos_token_id=self.eos_token_id,
+                additional_eos_token_list=self.additional_eos_token_list,
+                add_eos_when_return=self.add_eos_when_return,
+                do_sample=True,
+                repetition_penalty=repetition_penalty,
+                length_penalty=length_penalty,
+                pad_token_id=self.pad_token_id,
+                bos_token_id=self.bos_token_id,
+            )
+        else:
+            yield from _streaming_no_beam_search_generate(
+                self.decoder,
+                tokens=tokens,
+                max_length=max_length,
+                temperature=1,
+                top_k=50,
+                top_p=1,
+                eos_token_id=self.eos_token_id,
+                additional_eos_token_list=self.additional_eos_token_list,
+                add_eos_when_return=self.add_eos_when_return,
+                do_sample=False,
+                repetition_penalty=repetition_penalty,
+                length_penalty=length_penalty,
+                pad_token_id=self.pad_token_id,
+                bos_token_id=self.bos_token_id,
             )
 
 
@@ -146,14 +206,12 @@ def greedy_generate(
     num_beams=1,
     num_return_sequences=1,
     eos_token_id=None,
+    additional_eos_token_list=None,
+    add_eos_when_return=False,
     pad_token_id=0,
     repetition_penalty=1,
     length_penalty=1.0,
     bos_token_id=1,
-    streaming=False,
-    feat_mask=None,
-    ffn_mask=None,
-    layer_mask=None,
 ):
     """
     Search sequence greedily.
@@ -178,15 +236,13 @@ def greedy_generate(
             top_k=50,
             top_p=1,
             eos_token_id=eos_token_id,
+            additional_eos_token_list=additional_eos_token_list,
+            add_eos_when_return=add_eos_when_return,
             do_sample=False,
             repetition_penalty=repetition_penalty,
             length_penalty=length_penalty,
             pad_token_id=pad_token_id,
             bos_token_id=bos_token_id,
-            streaming=streaming,
-            feat_mask=feat_mask,
-            ffn_mask=ffn_mask,
-            layer_mask=layer_mask,
         )
     else:
         token_ids = _beam_search_generate(
@@ -199,15 +255,13 @@ def greedy_generate(
             top_k=50,
             top_p=1,
             eos_token_id=eos_token_id,
+            additional_eos_token_list=additional_eos_token_list,
+            add_eos_when_return=add_eos_when_return,
             do_sample=False,
             repetition_penalty=repetition_penalty,
             length_penalty=length_penalty,
             pad_token_id=pad_token_id,
             bos_token_id=bos_token_id,
-            # streaming=streaming,
-            feat_mask=feat_mask,
-            ffn_mask=ffn_mask,
-            layer_mask=layer_mask,
         )
 
     return token_ids
@@ -224,11 +278,12 @@ def sample_generate(
     top_k=50,
     top_p=1.0,
     eos_token_id=None,
+    additional_eos_token_list=None,
+    add_eos_when_return=False,
     pad_token_id=0,
     repetition_penalty=1.0,
     length_penalty=1.0,
     bos_token_id=1,
-    streaming=False,
 ):
     """
     generate sequence in sampling way.
@@ -257,12 +312,13 @@ def sample_generate(
             top_k=top_k,
             top_p=top_p,
             eos_token_id=eos_token_id,
+            additional_eos_token_list=additional_eos_token_list,
+            add_eos_when_return=add_eos_when_return,
             do_sample=True,
             repetition_penalty=repetition_penalty,
             length_penalty=length_penalty,
             pad_token_id=pad_token_id,
             bos_token_id=bos_token_id,
-            streaming=streaming,
         )
     else:
         token_ids = _beam_search_generate(
@@ -275,18 +331,19 @@ def sample_generate(
             top_k=top_k,
             top_p=top_p,
             eos_token_id=eos_token_id,
+            additional_eos_token_list=additional_eos_token_list,
+            add_eos_when_return=add_eos_when_return,
             do_sample=True,
             repetition_penalty=repetition_penalty,
             length_penalty=length_penalty,
             pad_token_id=pad_token_id,
             bos_token_id=bos_token_id,
-            # streaming=streaming,
         )
     return token_ids
 
 
 @torch.no_grad()
-def _no_beam_search_generate(
+def _streaming_no_beam_search_generate(
     decoder,
     tokens,
     inference_params=None,
@@ -295,21 +352,23 @@ def _no_beam_search_generate(
     top_k=50,
     top_p=1.0,
     eos_token_id=None,
+    additional_eos_token_list=None,
+    add_eos_when_return=False,
     do_sample=True,
     repetition_penalty=1.0,
     length_penalty=1.0,
     pad_token_id=0,
     bos_token_id=1,
-    streaming=False,
-    feat_mask=None,
-    ffn_mask=None,
-    layer_mask=None,
 ):
     batch_size = tokens.size(0)
-    if eos_token_id is None:
-        _eos_token_id = -1
-    else:
-        _eos_token_id = eos_token_id
+    if eos_token_id is not None:
+        if not isinstance(eos_token_id, (List, Tuple)):
+            eos_token_id = [eos_token_id]
+        if additional_eos_token_list is not None:
+            if not isinstance(additional_eos_token_list, (List, Tuple)):
+                additional_eos_token_list = [additional_eos_token_list]
+            eos_token_id.extend(additional_eos_token_list)
+        eos_token_id = torch.LongTensor(eos_token_id).to(tokens.device)
 
     has_bos = torch.all(tokens[:, 0].eq(bos_token_id))
     if has_bos:
@@ -318,12 +377,10 @@ def _no_beam_search_generate(
         bos_pos = torch.where(bos_sum.eq(bos_sum[:, -1:]), 0, 1)
         to_atten_x = bos_pos[:, :, None]
         to_atten_y = bos_pos[:, None, :]
-        # attention_mask = torch.einsum('bno,bom->bnm', to_atten_x, to_atten_y).eq(1)
     else:
         bos_pos = torch.where(tokens.eq(bos_token_id), 1, 0)
         to_atten_x = bos_pos[:, :, None]
         to_atten_y = bos_pos[:, None, :]
-        # attention_mask = torch.einsum('bno,bom->bnm', to_atten_x, to_atten_y).eq(1)
     attention_mask = torch.logical_or(to_atten_x, to_atten_y).eq(1)
     if inference_params is None:
         inference_params = InferenceParams(
@@ -336,46 +393,22 @@ def _no_beam_search_generate(
             attention_mask=attention_mask,
         )
 
-    if layer_mask is None:
-        if feat_mask is None and ffn_mask is None:
-            scores = decoder(**{"input_ids": tokens, "inference_params": inference_params})
-        else:
-            scores = decoder(
-                **{
-                    "input_ids": tokens,
-                    "inference_params": inference_params,
-                    "feat_mask": feat_mask,
-                    "ffn_mask": ffn_mask,
-                }
-            )
-    else:
-        scores = decoder(
-            **{
-                "input_ids": tokens,
-                "inference_params": inference_params,
-                "feat_mask": feat_mask,
-                "ffn_mask": ffn_mask,
-                "layer_mask": layer_mask,
-            }
-        )
+    scores = decoder(**{"input_ids": tokens, "inference_params": inference_params})
 
     if isinstance(scores, (list, tuple)):
         scores = scores[0]
     scores = scores[:, -1].float()
     inference_params.sequence_len_offset += tokens.size(1)
-    if _eos_token_id != -1:
-        scores[:, _eos_token_id] = -1e12
+    if eos_token_id is not None:
+        scores[:, eos_token_id] = -1e12
+
     # The first token generated.
     next_tokens = scores.argmax(dim=-1, keepdim=True)
-    print(f"Input tokens: {tokens}")
-    _generated_idx = 0
-    print(f"gt - {_generated_idx} | ", next_tokens); _generated_idx += 1
     token_ids = torch.cat([tokens, next_tokens], dim=1)
-    if streaming:
-        yield token_ids
+    yield token_ids
+
     cur_len = token_ids.size(1)
     dones = token_ids.new_zeros(batch_size).eq(1)
-    # tokens = tokens[:, -1:]
 
     real_max_length = max_length
     max_lengths = tokens.new_full((tokens.size(0),), fill_value=max_length, dtype=torch.long)
@@ -396,28 +429,7 @@ def _no_beam_search_generate(
             # attention_mask = torch.einsum('bno,bom->bnm', to_atten_x, to_atten_y).eq(1)
         attention_mask = torch.logical_or(to_atten_x, to_atten_y).eq(1)
         inference_params.attention_mask = attention_mask
-        if layer_mask is None:
-            if feat_mask is None and ffn_mask is None:
-                scores = decoder(**{"input_ids": token_ids[:, -1:], "inference_params": inference_params})
-            else:
-                scores = decoder(
-                    **{
-                        "input_ids": token_ids[:, -1:],
-                        "inference_params": inference_params,
-                        "feat_mask": feat_mask,
-                        "ffn_mask": ffn_mask,
-                    }
-                )
-        else:
-            scores = decoder(
-                **{
-                    "input_ids": token_ids[:, -1:],
-                    "inference_params": inference_params,
-                    "feat_mask": feat_mask,
-                    "ffn_mask": ffn_mask,
-                    "layer_mask": layer_mask,
-                }
-            )
+        scores = decoder(**{"input_ids": token_ids[:, -1:], "inference_params": inference_params})
 
         if isinstance(scores, (list, tuple)):
             scores = scores[0]
@@ -433,15 +445,12 @@ def _no_beam_search_generate(
             )
             scores.scatter_(dim=1, index=token_ids, src=token_scores)
         # scores: [bsz, vocab_size]
-        import pdb; pdb.set_trace()
         if eos_token_id is not None and length_penalty != 1.0:
             # batch_size x vocab_size
-            token_scores = scores / cur_len**length_penalty
-            eos_mask = scores.new_ones(scores.size(1))
-            eos_mask[eos_token_id] = 0
-            eos_mask = eos_mask.unsqueeze(0).eq(1)
-
-            scores = scores.masked_scatter(eos_mask, token_scores)
+            eos_token_scores = scores[:, eos_token_id].clone()
+            scores = scores / cur_len**length_penalty
+            scores[:, eos_token_id] = eos_token_scores
+            del eos_token_scores
 
         if do_sample:
             if temperature > 0 and temperature != 1:
@@ -455,34 +464,173 @@ def _no_beam_search_generate(
         else:
             next_tokens = torch.argmax(scores, dim=-1)  # batch_size
 
-        if _eos_token_id != -1:
-            next_tokens = next_tokens.masked_fill(max_lengths.eq(cur_len + 1), _eos_token_id)
+        if eos_token_id is not None:
+            # When the generated result exceeds the length, its eos_token_id is set to the most basic terminator.
+            next_tokens = next_tokens.masked_fill(max_lengths.eq(cur_len + 1), eos_token_id[0])
         next_tokens = next_tokens.masked_fill(dones, pad_token_id)
         tokens = next_tokens.unsqueeze(1)
-
-        print(f"gt - {_generated_idx} | ", next_tokens); _generated_idx += 1
-
         token_ids = torch.cat([token_ids, tokens], dim=-1)  # batch_size x max_len
-        if streaming:
-            yield token_ids
 
-        end_mask = next_tokens.eq(_eos_token_id)
-        dones = dones.__or__(end_mask)
+        yield token_ids
+
+        if eos_token_id is not None:
+            end_mask = torch.any(next_tokens[:, None].eq(eos_token_id), dim=-1)
+            dones = dones.__or__(end_mask)
+
         cur_len += 1
 
         if dones.min() == 1:
             break
 
-    # if eos_token_id is not None:
-    #     # setting the eos at the maximum length position
-    #     tokens.scatter(index=max_lengths[:, None], dim=1, value=eos_token_id)
-    # if cur_len == max_length:
-    #     # If eos is not reached by the maximum length, forcibly replace the last word with eos
-    #     token_ids[:, -1].masked_fill_(~dones, eos_token_id)
-    # TODO Here we are simply adding an extra dimension for interface compatibility, but in the future it will need to
-    # be able to return multiple real results
-    if not streaming:
-        return token_ids[:, None]
+    # token_ids: [bsz, seqlen]
+    if eos_token_id is not None and add_eos_when_return:
+        token_ids = torch.cat([token_ids, token_ids.new_full((token_ids.size(0), 1), eos_token_id[0])], dim=1)
+
+
+@torch.no_grad()
+def _no_beam_search_generate(
+    decoder,
+    tokens,
+    inference_params=None,
+    max_length=20,
+    temperature=1.0,
+    top_k=50,
+    top_p=1.0,
+    eos_token_id=None,
+    additional_eos_token_list=None,
+    add_eos_when_return=False,
+    do_sample=True,
+    repetition_penalty=1.0,
+    length_penalty=1.0,
+    pad_token_id=0,
+    bos_token_id=1,
+):
+    batch_size = tokens.size(0)
+    if eos_token_id is not None:
+        if not isinstance(eos_token_id, (List, Tuple)):
+            eos_token_id = [eos_token_id]
+        if additional_eos_token_list is not None:
+            if not isinstance(additional_eos_token_list, (List, Tuple)):
+                additional_eos_token_list = [additional_eos_token_list]
+            eos_token_id.extend(additional_eos_token_list)
+        eos_token_id = torch.LongTensor(eos_token_id).to(tokens.device)
+
+    has_bos = torch.all(tokens[:, 0].eq(bos_token_id))
+    if has_bos:
+        bos_pos = torch.where(tokens.eq(bos_token_id), 1, 0)
+        bos_sum = bos_pos.cumsum(dim=-1)
+        bos_pos = torch.where(bos_sum.eq(bos_sum[:, -1:]), 0, 1)
+        to_atten_x = bos_pos[:, :, None]
+        to_atten_y = bos_pos[:, None, :]
+    else:
+        bos_pos = torch.where(tokens.eq(bos_token_id), 1, 0)
+        to_atten_x = bos_pos[:, :, None]
+        to_atten_y = bos_pos[:, None, :]
+    attention_mask = torch.logical_or(to_atten_x, to_atten_y).eq(1)
+    if inference_params is None:
+        inference_params = InferenceParams(
+            max_sequence_len=max_length,
+            max_batch_size=tokens.size(0),
+            sequence_len_offset=0,
+            batch_size_offset=0,
+            key_value_memory_dict=None,
+            lengths_per_sample=None,
+            attention_mask=attention_mask,
+        )
+
+    scores = decoder(**{"input_ids": tokens, "inference_params": inference_params})
+
+    if isinstance(scores, (list, tuple)):
+        scores = scores[0]
+    scores = scores[:, -1].float()
+    inference_params.sequence_len_offset += tokens.size(1)
+    if eos_token_id is not None:
+        scores[:, eos_token_id] = -1e12
+
+    # The first token generated.
+    next_tokens = scores.argmax(dim=-1, keepdim=True)
+    token_ids = torch.cat([tokens, next_tokens], dim=1)
+    cur_len = token_ids.size(1)
+    dones = token_ids.new_zeros(batch_size).eq(1)
+
+    real_max_length = max_length
+    max_lengths = tokens.new_full((tokens.size(0),), fill_value=max_length, dtype=torch.long)
+
+    while cur_len < real_max_length:
+        # batch_size x vocab_size
+        if has_bos:
+            bos_pos = torch.where(token_ids.eq(bos_token_id), 1, 0)
+            bos_sum = bos_pos.cumsum(dim=-1)
+            bos_pos = torch.where(bos_sum.eq(bos_sum[:, -1:]), 0, 1)
+            to_atten_x = bos_pos[:, :, None]
+            to_atten_y = bos_pos[:, None, :]
+            # attention_mask = torch.einsum('bno,bom->bnm', to_atten_x, to_atten_y).eq(1)
+        else:
+            bos_pos = torch.where(token_ids.eq(bos_token_id), 1, 0)
+            to_atten_x = bos_pos[:, :, None]
+            to_atten_y = bos_pos[:, None, :]
+            # attention_mask = torch.einsum('bno,bom->bnm', to_atten_x, to_atten_y).eq(1)
+        attention_mask = torch.logical_or(to_atten_x, to_atten_y).eq(1)
+        inference_params.attention_mask = attention_mask
+        scores = decoder(**{"input_ids": token_ids[:, -1:], "inference_params": inference_params})
+
+        if isinstance(scores, (list, tuple)):
+            scores = scores[0]
+        scores = scores[:, -1].float()
+        inference_params.sequence_len_offset += 1
+
+        if repetition_penalty != 1.0:
+            token_scores = scores.gather(dim=1, index=token_ids)
+            lt_zero_mask = token_scores.lt(0).float()
+            ge_zero_mask = lt_zero_mask.eq(0).float()
+            token_scores = (
+                lt_zero_mask * repetition_penalty * token_scores + ge_zero_mask / repetition_penalty * token_scores
+            )
+            scores.scatter_(dim=1, index=token_ids, src=token_scores)
+        # scores: [bsz, vocab_size]
+        if eos_token_id is not None and length_penalty != 1.0:
+            # batch_size x vocab_size
+            eos_token_scores = scores[:, eos_token_id].clone()
+            scores = scores / cur_len**length_penalty
+            scores[:, eos_token_id] = eos_token_scores
+            del eos_token_scores
+
+        if do_sample:
+            if temperature > 0 and temperature != 1:
+                scores = scores / temperature
+
+            scores = top_k_top_p_filtering(scores, top_k, top_p, min_tokens_to_keep=2)
+            # add 1e-12 to avoid https://github.com/pytorch/pytorch/pull/27523
+            probs = F.softmax(scores, dim=-1) + 1e-12
+
+            next_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)  # batch_size
+        else:
+            next_tokens = torch.argmax(scores, dim=-1)  # batch_size
+
+        if eos_token_id is not None:
+            # When the generated result exceeds the length, its eos_token_id is set to the most basic terminator.
+            next_tokens = next_tokens.masked_fill(max_lengths.eq(cur_len + 1), eos_token_id[0])
+        next_tokens = next_tokens.masked_fill(dones, pad_token_id)
+        tokens = next_tokens.unsqueeze(1)
+        token_ids = torch.cat([token_ids, tokens], dim=-1)  # batch_size x max_len
+
+        if eos_token_id is not None:
+            end_mask = torch.any(next_tokens[:, None].eq(eos_token_id), dim=-1)
+            dones = dones.__or__(end_mask)
+
+        cur_len += 1
+
+        if dones.min() == 1:
+            break
+
+    # token_ids: [bsz, seqlen]
+    if eos_token_id is not None and add_eos_when_return:
+        token_ids = torch.cat([token_ids, token_ids.new_full((token_ids.size(0), 1), eos_token_id[0])], dim=1)
+
+    # In order to maintain consistency with the results returned by beam search,
+    #  a new dimension is added here representing num_return_sequences.
+    # token_ids: [bsz, num_return_sequences, seqlen]
+    return token_ids[:, None]
 
 
 @torch.no_grad()
@@ -497,23 +645,26 @@ def _beam_search_generate(
     top_k=50,
     top_p=1.0,
     eos_token_id=None,
+    additional_eos_token_list=None,
+    add_eos_when_return=False,
     do_sample=True,
     repetition_penalty=1.0,
     length_penalty=1.0,
     pad_token_id=0,
     bos_token_id=1,
-    feat_mask=None,
-    ffn_mask=None,
-    layer_mask=None,
 ) -> torch.LongTensor:
 
     device = _get_model_device(decoder)
     batch_size = tokens.size(0)
 
-    if eos_token_id is None:
-        _eos_token_id = -1
-    else:
-        _eos_token_id = eos_token_id
+    if eos_token_id is not None:
+        if not isinstance(eos_token_id, (List, Tuple)):
+            eos_token_id = [eos_token_id]
+        if additional_eos_token_list is not None:
+            if not isinstance(additional_eos_token_list, (List, Tuple)):
+                additional_eos_token_list = [additional_eos_token_list]
+            eos_token_id.extend(additional_eos_token_list)
+        eos_token_id = torch.LongTensor(eos_token_id).to(tokens.device)
 
     has_bos = torch.all(tokens[:, 0].eq(bos_token_id))
 
@@ -542,38 +693,18 @@ def _beam_search_generate(
             attention_mask=attention_mask,
         )
 
-    if layer_mask is None:
-        if feat_mask is None and ffn_mask is None:
-            scores = decoder(**{"input_ids": tokens, "inference_params": inference_params})
-        else:
-            scores = decoder(
-                **{
-                    "input_ids": tokens,
-                    "inference_params": inference_params,
-                    "feat_mask": feat_mask,
-                    "ffn_mask": ffn_mask,
-                }
-            )
-    else:
-        scores = decoder(
-            **{
-                "input_ids": tokens,
-                "inference_params": inference_params,
-                "feat_mask": feat_mask,
-                "ffn_mask": ffn_mask,
-                "layer_mask": layer_mask,
-            }
-        )
+    scores = decoder(**{"input_ids": tokens, "inference_params": inference_params})
 
     if isinstance(scores, (list, tuple)):
         scores = scores[0]
     scores = scores[:, -1].float()
     inference_params.sequence_len_offset += tokens.size(1)
-    if _eos_token_id != -1:
-        scores[:, _eos_token_id] = -1e12
+    if eos_token_id is not None:
+        scores[:, eos_token_id] = -1e12
     vocab_size = scores.size(1)
     assert vocab_size >= num_beams, "num_beams should be smaller than " "the number of vocabulary size."
 
+    # The first token generated.
     if do_sample:
         probs = F.softmax(scores, dim=-1) + 1e-12
         # (batch_size, num_beams)
@@ -626,28 +757,7 @@ def _beam_search_generate(
         inference_params.attention_mask = attention_mask
         # (bsz x num_beams, vocab_size)
 
-        if layer_mask is None:
-            if feat_mask is None and ffn_mask is None:
-                scores = decoder(**{"input_ids": token_ids[:, -1:], "inference_params": inference_params})
-            else:
-                scores = decoder(
-                    **{
-                        "input_ids": token_ids[:, -1:],
-                        "inference_params": inference_params,
-                        "feat_mask": feat_mask,
-                        "ffn_mask": ffn_mask,
-                    }
-                )
-        else:
-            scores = decoder(
-                **{
-                    "input_ids": token_ids[:, -1:],
-                    "inference_params": inference_params,
-                    "feat_mask": feat_mask,
-                    "ffn_mask": ffn_mask,
-                    "layer_mask": layer_mask,
-                }
-            )
+        scores = decoder(**{"input_ids": token_ids[:, -1:], "inference_params": inference_params})
 
         if isinstance(scores, (list, tuple)):
             scores = scores[0]
@@ -662,10 +772,11 @@ def _beam_search_generate(
             )
             scores.scatter_(dim=1, index=token_ids, src=token_scores)
 
-        if _eos_token_id != -1:
+        if eos_token_id is not None:
             max_len_eos_mask = max_lengths.eq(cur_len + 1)
-            eos_scores = scores[:, _eos_token_id]
-            scores[:, _eos_token_id] = torch.where(max_len_eos_mask, eos_scores + 1e32, eos_scores)
+            # When the generated result exceeds the length, its eos_token_id is set to the most basic terminator.
+            eos_scores = scores[:, eos_token_id[0]]
+            scores[:, eos_token_id[0]] = torch.where(max_len_eos_mask, eos_scores + 1e32, eos_scores)
 
         if do_sample:
             if temperature > 0 and temperature != 1:
@@ -703,11 +814,7 @@ def _beam_search_generate(
             from_which_beam = torch.floor(ids.float() / vocab_size).long()
             next_tokens = ids % vocab_size  # (batch_size, 2*num_beams)
 
-        # next_scores, sorted_inds = next_scores.sort(dim=-1, descending=True)
-        # next_tokens = next_tokens.gather(dim=1, index=sorted_inds)
-        # from_which_beam = from_which_beam.gather(dim=1, index=sorted_inds)
-
-        not_eos_mask = next_tokens.ne(_eos_token_id)
+        not_eos_mask = torch.all(next_tokens[..., None].ne(eos_token_id), dim=-1)
         keep_mask = not_eos_mask.cumsum(dim=1).le(num_beams)
         keep_mask = not_eos_mask.__and__(keep_mask)
 
@@ -722,7 +829,9 @@ def _beam_search_generate(
             eos_beam_ind = torch.arange(num_beams).to(token_ids).repeat(batch_size)
             eos_beam_idx = from_which_beam[:, :num_beams].reshape(-1)
         else:
-            effective_eos_mask = next_tokens[:, :num_beams].eq(_eos_token_id)  # batch_size x num_beams
+            effective_eos_mask = torch.any(
+                next_tokens[:, :num_beams][..., None].eq(eos_token_id), dim=-1
+            )  # batch_size x num_beams
             if effective_eos_mask.sum().gt(0):
                 eos_batch_idx, eos_beam_ind = effective_eos_mask.nonzero(as_tuple=True)
                 eos_beam_idx = eos_batch_idx * num_beams * 2 + eos_beam_ind
@@ -737,7 +846,7 @@ def _beam_search_generate(
             ):
                 if not dones[batch_idx]:
                     score = next_scores[batch_idx, beam_ind].item()
-                    if _eos_token_id != -1:
+                    if eos_token_id is not None:
                         hypos[batch_idx].add(_token_ids[batch_idx * num_beams + beam_idx, :cur_len].clone(), score)
                     else:
                         hypos[batch_idx].add(_token_ids[batch_idx * num_beams + beam_idx].clone(), score)
@@ -768,8 +877,9 @@ def _beam_search_generate(
         _best = []
         for j, hyp in zip(range(num_return_sequences), sorted_hyp):
             hyp = hyp[1]
-            if _eos_token_id != -1:
-                hyp = torch.cat([hyp, token_ids.new_ones(1) * _eos_token_id])
+            if eos_token_id is not None and add_eos_when_return:
+                # When forcing eos to be added at the end of the generated result, use the most basic text terminator.
+                hyp = torch.cat([hyp, token_ids.new_ones(1) * eos_token_id[0]])
             tgt_len[i, j] = len(hyp)
             _best.append(hyp)
         best.append(_best)
@@ -780,6 +890,7 @@ def _beam_search_generate(
         for j, _hypo in enumerate(hypo):
             decoded[i, j, : tgt_len[i, j]] = _hypo
 
+    # decoded: [bsz, num_return_sequences, seqlen]
     return decoded
 
 

--- a/internlm/apis/inference.py
+++ b/internlm/apis/inference.py
@@ -163,9 +163,9 @@ class SequenceGenerator:
         length_penalty: float = 1.0,
     ):
         if not do_sample:
-            temperature = (1,)
-            top_k = (50,)
-            top_p = (1,)
+            temperature = 1
+            top_k = 50
+            top_p = 1
         yield from _streaming_no_beam_search_generate(
             self.decoder,
             tokens=tokens,

--- a/internlm/apis/inference.py
+++ b/internlm/apis/inference.py
@@ -162,40 +162,26 @@ class SequenceGenerator:
         repetition_penalty: float = 1,
         length_penalty: float = 1.0,
     ):
-        if do_sample:
-            yield from _streaming_no_beam_search_generate(
-                self.decoder,
-                tokens=tokens,
-                max_length=max_length,
-                temperature=temperature,
-                top_k=top_k,
-                top_p=top_p,
-                eos_token_id=self.eos_token_id,
-                additional_eos_token_list=self.additional_eos_token_list,
-                add_eos_when_return=self.add_eos_when_return,
-                do_sample=True,
-                repetition_penalty=repetition_penalty,
-                length_penalty=length_penalty,
-                pad_token_id=self.pad_token_id,
-                bos_token_id=self.bos_token_id,
-            )
-        else:
-            yield from _streaming_no_beam_search_generate(
-                self.decoder,
-                tokens=tokens,
-                max_length=max_length,
-                temperature=1,
-                top_k=50,
-                top_p=1,
-                eos_token_id=self.eos_token_id,
-                additional_eos_token_list=self.additional_eos_token_list,
-                add_eos_when_return=self.add_eos_when_return,
-                do_sample=False,
-                repetition_penalty=repetition_penalty,
-                length_penalty=length_penalty,
-                pad_token_id=self.pad_token_id,
-                bos_token_id=self.bos_token_id,
-            )
+        if not do_sample:
+            temperature = (1,)
+            top_k = (50,)
+            top_p = (1,)
+        yield from _streaming_no_beam_search_generate(
+            self.decoder,
+            tokens=tokens,
+            max_length=max_length,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            eos_token_id=self.eos_token_id,
+            additional_eos_token_list=self.additional_eos_token_list,
+            add_eos_when_return=self.add_eos_when_return,
+            do_sample=do_sample,
+            repetition_penalty=repetition_penalty,
+            length_penalty=length_penalty,
+            pad_token_id=self.pad_token_id,
+            bos_token_id=self.bos_token_id,
+        )
 
 
 @torch.no_grad()

--- a/internlm/apis/inference.py
+++ b/internlm/apis/inference.py
@@ -472,6 +472,8 @@ def _streaming_no_beam_search_generate(
     if eos_token_id is not None and add_eos_when_return:
         token_ids = torch.cat([token_ids, token_ids.new_full((token_ids.size(0), 1), eos_token_id[0])], dim=1)
 
+    yield token_ids
+
 
 @torch.no_grad()
 def _no_beam_search_generate(

--- a/tools/load_internlm_model.py
+++ b/tools/load_internlm_model.py
@@ -137,8 +137,8 @@ def initialize_internlm_model(
         model_type (str): The types of models supported by train_internlm, such as "LLAMA" or "INTERNLM". Note that
             when loading these models, ``model_type`` can only be "LLAMA".
         ckpt_dir (str): Directory where model checkpoints are stored. Its format needs to be like this:
-            (a) local path, such as: "local:/mnt/petrelfs/share_data/llm_llama/codellama_raw/codellama-7b";
-            (b) boto3 path, such as: "boto3:s3://checkpoints_ssd_02.10.135.7.249/0831/origin_llama/7B".
+            (a) local path, such as: "local:{your local path}";
+            (b) boto3 path, such as: "boto3:s3://{bucket name}.{ip}/{your ceph path}".
         model_config (Optional[Union[Dict, str]], optional): Configuration of models. Defaults to None.
         del_model_prefix (bool, optional):  Whether to remove the "model." string in the key in state_dict.
             Defaults to False.

--- a/tools/load_internlm_model.py
+++ b/tools/load_internlm_model.py
@@ -169,8 +169,8 @@ def initialize_internlm_model(
         init_storage_manager(False, None, None)
     except AssertionError:
         pass
-    except Exception:
-        raise Exception
+    except Exception as e:
+        raise e
 
     model_config["dtype"] = param_dtype
     model_config["parallel_output"] = False

--- a/tools/load_internlm_model.py
+++ b/tools/load_internlm_model.py
@@ -134,8 +134,7 @@ def initialize_internlm_model(
     """Initialize internlm model.
 
     Args:
-        model_type (str): The types of models supported by train_internlm, such as "LLAMA" or "INTERNLM". Note that
-            when loading these models, ``model_type`` can only be "LLAMA".
+        model_type (str): The types of models supported by train_internlm, such as "INTERNLM".
         ckpt_dir (str): Directory where model checkpoints are stored. Its format needs to be like this:
             (a) local path, such as: "local:{your local path}";
             (b) boto3 path, such as: "boto3:s3://{bucket name}.{ip}/{your ceph path}".

--- a/tools/load_internlm_model.py
+++ b/tools/load_internlm_model.py
@@ -134,7 +134,7 @@ def initialize_internlm_model(
     """Initialize internlm model.
 
     Args:
-        model_type (str): The types of models supported by train_internlm, such as "INTERNLM".
+        model_type (str): The types of models supported by internlm framework, such as "INTERNLM".
         ckpt_dir (str): Directory where model checkpoints are stored. Its format needs to be like this:
             (a) local path, such as: "local:{your local path}";
             (b) boto3 path, such as: "boto3:s3://{bucket name}.{ip}/{your ceph path}".

--- a/tools/load_internlm_model.py
+++ b/tools/load_internlm_model.py
@@ -139,14 +139,13 @@ def initialize_internlm_model(
         ckpt_dir (str): Directory where model checkpoints are stored. Its format needs to be like this:
             (a) local path, such as: "local:/mnt/petrelfs/share_data/llm_llama/codellama_raw/codellama-7b";
             (b) boto3 path, such as: "boto3:s3://checkpoints_ssd_02.10.135.7.249/0831/origin_llama/7B".
+        model_config (Optional[Union[Dict, str]], optional): Configuration of models. Defaults to None.
         del_model_prefix (bool, optional):  Whether to remove the "model." string in the key in state_dict.
             Defaults to False.
         param_dtype (torch.dtype, optional): The dtype of the model at inference time. This value can be a string.
             Use "torch.tf32" when you want to use tf32 to do the inference. Defaults to torch.bfloat16.
         training (bool, optional): model.train() or model.eval(). Defaults to False.
         seed (int, optional): Defaults to 1024.
-        model_config (Optional[Union[Dict, str]], optional): Configuration of models.
-            Defaults to None.
     """
 
     if gpc.is_rank_for_log():
@@ -211,6 +210,7 @@ def initialize_internlm_model(
 def get_model_device(model):
     for param in model.parameters():
         device = param.device
+        break
     return device
 
 

--- a/tools/load_internlm_model.py
+++ b/tools/load_internlm_model.py
@@ -1,0 +1,299 @@
+import inspect
+import logging
+import os
+import re
+from typing import Callable, Dict, List, Optional, Union
+
+import torch
+
+from internlm.apis.inference import SequenceGenerator
+from internlm.core.context import ParallelMode
+from internlm.core.context import global_context as gpc
+from internlm.initialize.launch import launch_from_torch
+from internlm.train import initialize_model
+from internlm.utils.registry import MODEL_INITIALIZER
+from internlm.utils.storage_manager import get_fns, init_storage_manager, llm_load
+from tools.transformers.interface import GenerationConfig
+
+logger = logging.getLogger(__file__)
+logging.basicConfig(level=logging.INFO)
+
+
+def merge_pp_within_tp(folder, del_model_prefix: bool = False) -> Dict[str, torch.Tensor]:
+    """Merge checkpoints from different pipelines of the model.
+
+    Args:
+        folder (str): checkpoint directory.
+        del_model_prefix (bool, optional): Whether to remove the "model." string in the key in state_dict. Defaults
+            to False.
+
+    Returns:
+        Dict[str, torch.Tensor]: A state_dict that belongs to the model of the current tensor parallel rank.
+    """
+    assert folder is not None, "Please specify the folder of the pretrained model"
+    fns = get_fns(folder)
+
+    model_fns = []
+    for fn in fns:
+        # filter with `_t` is for avoiding conflict with model_config.py
+        if fn.startswith("model_t") and not fn.endswith("md5"):
+            model_fns.append(fn)
+
+    max_tp, max_pp = -1, -1
+    for fn in model_fns:
+        _, tp, pp = os.path.splitext(fn)[0].split("_")
+        max_pp = max(max_pp, int(pp[2:]) + 1)
+        max_tp = max(max_tp, int(tp[2:]) + 1)
+
+    if max_tp < 0 or max_pp < 0:
+        raise RuntimeError(f"Could not find any model checkpoints starting with 'model_t' in the folder: {folder}")
+
+    assert max_tp == gpc.get_world_size(ParallelMode.TENSOR), (
+        f"Expected TP size in loaded checkpoint to be equal to TP size in current config, but got {max_tp} in "
+        f"checkpoint and {gpc.get_world_size(ParallelMode.TENSOR)} in current config"
+    )
+    tp = gpc.get_local_rank(ParallelMode.TENSOR)
+
+    layer_shift = 0
+
+    tp_states = {}
+    for pp in range(max_pp):
+        _layer_shift = 0
+        model_name = f"model_tp{tp}_pp{pp}.pt"
+        states = llm_load(os.path.join(folder, model_name), map_location="cpu")
+
+        keys = list(states.keys())
+        for key in keys:
+            match = re.search(r"\.\d+\.", key)
+            if match is not None:  # Indicate layer related. shift is required.
+                s, e = match.span()
+                layer_idx = int(key[s + 1 : e - 1]) + layer_shift
+                _layer_shift = max(_layer_shift, int(key[s + 1 : e - 1]))
+                name = key[:s] + f".{layer_idx}." + key[e:]
+                if del_model_prefix:
+                    name = name[6:] if name.startswith("model.") else name
+                tp_states[name] = states[key]
+            else:
+                name = key
+                if del_model_prefix:
+                    name = name[6:] if name.startswith("model.") else name
+                tp_states[name] = states[key]
+        layer_shift += _layer_shift + 1
+
+    return tp_states
+
+
+def match_fn_signature(func: Callable, args_dict: Dict) -> None:
+    """Matches the parameters of a function.
+
+    Given a function and a parameter dictionary, remove key-value pairs in the dictionary
+     that do not match the parameters of the function.
+
+    Args:
+        func (Callable): specific function.
+        args_dict (Dict): parameter dictionary.
+    """
+    params = inspect.signature(func).parameters
+    params = set(params)
+    args_set = set(args_dict).difference(params)
+    for _name in args_set:
+        args_dict.pop(_name)
+    if len(args_set) and gpc.is_rank_for_log():
+        logger.warning(f"These args:{args_set} are popped for func:{func.__name__}.")
+
+
+def get_tp_rank() -> int:
+    """Get the tensor parallel rank.
+    This script uses torchrun to initialize the environment, so RANK in the environment variable is the tensor
+     parallel rank.
+
+    Returns:
+        int: The tensor parallel rank to which the current process belongs.
+    """
+    return int(os.environ.get("RANK", 0))
+
+
+def get_tp_world_size() -> int:
+    """Get the tensor parallel world size.
+
+    Returns:
+        int: The tensor parallel world size to which the current process belongs.
+    """
+    return int(os.environ.get("WORLD_SIZE", 0))
+
+
+def initialize_internlm_model(
+    model_type: str,
+    ckpt_dir: str,
+    model_config: Dict,
+    del_model_prefix: bool = False,
+    param_dtype: torch.dtype = torch.bfloat16,
+    training: bool = False,
+    seed: int = 1024,
+) -> torch.nn.Module:
+    """Initialize internlm model.
+
+    Args:
+        model_type (str): The types of models supported by train_internlm, such as "LLAMA" or "INTERNLM". Note that
+            when loading these models, ``model_type`` can only be "LLAMA".
+        ckpt_dir (str): Directory where model checkpoints are stored. Its format needs to be like this:
+            (a) local path, such as: "local:/mnt/petrelfs/share_data/llm_llama/codellama_raw/codellama-7b";
+            (b) boto3 path, such as: "boto3:s3://checkpoints_ssd_02.10.135.7.249/0831/origin_llama/7B".
+        del_model_prefix (bool, optional):  Whether to remove the "model." string in the key in state_dict.
+            Defaults to False.
+        param_dtype (torch.dtype, optional): The dtype of the model at inference time. This value can be a string.
+            Use "torch.tf32" when you want to use tf32 to do the inference. Defaults to torch.bfloat16.
+        training (bool, optional): model.train() or model.eval(). Defaults to False.
+        seed (int, optional): Defaults to 1024.
+        model_config (Optional[Union[Dict, str]], optional): Configuration of models.
+            Defaults to None.
+    """
+
+    if gpc.is_rank_for_log():
+        logger.info(f"tp world size: {get_tp_world_size()}.")
+
+    if isinstance(param_dtype, str):
+        try:
+            param_dtype = eval(param_dtype)  # pylint: disable=W0123
+        finally:
+            pass
+    if param_dtype == "torch.tf32":
+        param_dtype = torch.float32
+        torch.backends.cudnn.allow_tf32 = True
+        torch.backends.cuda.matmul.allow_tf32 = True
+
+    if not isinstance(param_dtype, torch.dtype):
+        raise ValueError("Parameter ``param_dtype`` is not right.")
+
+    try:
+        init_storage_manager(False, None, None)
+    except AssertionError:
+        pass
+    except Exception:
+        raise Exception
+
+    model_config["dtype"] = param_dtype
+    model_config["parallel_output"] = False
+    match_fn_signature(MODEL_INITIALIZER.get_module(model_type), model_config)
+    if gpc.is_rank_for_log():
+        logger.info(f"model_config: {model_config}.")
+    launch_from_torch(
+        config=dict(
+            model_type=model_type,
+            model=model_config,
+            parallel=dict(
+                zero1=dict(size=1, fsdp=False),
+                pipeline=dict(size=1, interleaved_overlap=True),
+                tensor=get_tp_world_size(),
+                sequence_parallel=0,
+            ),
+        ),
+        seed=seed,
+    )
+    model = initialize_model()
+    # Directly get the origin model without NativeAMP wrapper.
+    model = model.model
+
+    state_dict = merge_pp_within_tp(ckpt_dir, del_model_prefix=del_model_prefix)
+    load_info = model.load_state_dict(state_dict, strict=False)
+    logger.info(f"Rank:{gpc.get_local_rank(ParallelMode.TENSOR)}. Load info: {load_info}.")
+
+    model.to(param_dtype)
+    if training:
+        model.train()
+    else:
+        model.eval()
+    model.cuda()
+    torch.distributed.barrier()
+    return model
+
+
+def get_model_device(model):
+    for param in model.parameters():
+        device = param.device
+    return device
+
+
+def internlm_interactive_generation(
+    model,
+    tokenizer,
+    prompt,
+    generation_config: Optional[GenerationConfig] = None,
+    additional_eos_token_list: Optional[Union[int, List[int]]] = None,
+):
+    sequenece_generator = SequenceGenerator(
+        decoder=model,
+        eos_token_id=tokenizer.eos_id(),
+        pad_token_id=tokenizer.eos_id(),
+        bos_token_id=tokenizer.bos_id(),
+        additional_eos_token_list=additional_eos_token_list,
+    )
+    additional_eos_token_list = torch.LongTensor(additional_eos_token_list)
+    input_ids = [tokenizer.bos_id()] + tokenizer.encode(prompt)
+    input_ids = torch.LongTensor([input_ids]).to(get_model_device(model))
+    output_generator = sequenece_generator.streaming_generate(
+        tokens=input_ids,
+        max_length=generation_config.max_length,
+        do_sample=generation_config.do_sample,
+        temperature=generation_config.temperature,
+        top_k=40,
+        top_p=generation_config.top_p,
+        repetition_penalty=generation_config.repetition_penalty,
+        length_penalty=1.0,
+    )
+    for token_ids in output_generator:
+        token_ids = token_ids.cpu().tolist()[0]
+        if torch.any(additional_eos_token_list == token_ids[-1]):
+            token_ids.pop()
+        cur_output = tokenizer.decode(token_ids)
+        cur_output = cur_output[len(prompt) :]
+        yield cur_output
+
+
+if __name__ == "__main__":
+    """
+    Here is a simple example to generate with origin internlm model architecture.
+    Use the following command to run:
+    >>> torchrun --master_port 12331 --nnodes=1 --node_rank=0 --nproc_per_node=1 tools/load_internlm_model.py
+    """
+    model = initialize_internlm_model(
+        model_type="INTERNLM",
+        ckpt_dir="[Please replace this with the directory where the internlm model weights are stored]",
+        model_config=dict(
+            checkpoint=False,
+            num_attention_heads=32,
+            embed_split_hidden=True,
+            vocab_size=103168,
+            embed_grad_scale=1,
+            parallel_output=False,
+            hidden_size=4096,
+            num_layers=32,
+            mlp_ratio=8 / 3,
+            apply_post_layer_norm=False,
+            dtype="torch.bfloat16",
+            norm_type="rmsnorm",
+            layer_norm_epsilon=1e-5,
+            use_flash_attn=True,
+            num_chunks=1,
+            use_dynamic_ntk_rope=True,
+        ),
+        del_model_prefix=True,
+    )
+
+    from sentencepiece import SentencePieceProcessor
+
+    prompt = """<|User|>:{query}<eoh>\n<|Bot|>:"""
+    prompt = prompt.replace("{query}", "hello")
+    tokenizer = SentencePieceProcessor("tools/V7_sft.model")  # pylint: disable=E1121
+
+    generation_config = GenerationConfig()
+    output_generator = internlm_interactive_generation(
+        model=model,
+        tokenizer=tokenizer,
+        prompt=prompt,
+        generation_config=generation_config,
+        additional_eos_token_list=[103028],
+    )
+
+    for text in output_generator:
+        print(text)

--- a/tools/transformers/interface.py
+++ b/tools/transformers/interface.py
@@ -5,7 +5,6 @@ from typing import Callable, List, Optional
 
 import torch
 from torch import nn
-from transformers import AutoModel, AutoTokenizer
 from transformers.generation.utils import LogitsProcessorList, StoppingCriteriaList
 from transformers.utils import logging
 
@@ -14,16 +13,16 @@ logger = logging.get_logger(__name__)
 
 @dataclass
 class GenerationConfig:
-    max_length: Optional[int] = None
-    top_p: Optional[float] = None
-    temperature: Optional[float] = None
-    do_sample: Optional[bool] = True
-    repetition_penalty: Optional[float] = 1.0
+    max_length: int = 64
+    top_p: float = 0.8
+    temperature: float = 0.8
+    do_sample: bool = True
+    repetition_penalty: float = 1.0
 
 
 @torch.inference_mode()
 def generate_interactive(
-    model, 
+    model,
     tokenizer,
     prompt,
     generation_config: Optional[GenerationConfig] = None,
@@ -38,12 +37,15 @@ def generate_interactive(
     for k, v in inputs.items():
         inputs[k] = v.cuda()
     input_ids = inputs["input_ids"]
-    batch_size, input_ids_seq_length = input_ids.shape[0], input_ids.shape[-1]
+    batch_size, input_ids_seq_length = input_ids.shape[0], input_ids.shape[-1]  # noqa: F841  # pylint: disable=W0612
     if generation_config is None:
         generation_config = model.generation_config
     generation_config = copy.deepcopy(generation_config)
     model_kwargs = generation_config.update(**kwargs)
-    bos_token_id, eos_token_id = generation_config.bos_token_id, generation_config.eos_token_id
+    bos_token_id, eos_token_id = (  # noqa: F841  # pylint: disable=W0612
+        generation_config.bos_token_id,
+        generation_config.eos_token_id,
+    )
     if isinstance(eos_token_id, int):
         eos_token_id = [eos_token_id]
     if additional_eos_token_id is not None:
@@ -59,7 +61,7 @@ def generate_interactive(
     elif generation_config.max_new_tokens is not None:
         generation_config.max_length = generation_config.max_new_tokens + input_ids_seq_length
         if not has_default_max_length:
-            logger.warn(
+            logger.warn(  # pylint: disable=W4902
                 f"Both `max_new_tokens` (={generation_config.max_new_tokens}) and `max_length`(="
                 f"{generation_config.max_length}) seem to have been set. `max_new_tokens` will take precedence. "
                 "Please refer to the documentation for more information. "
@@ -119,11 +121,9 @@ def generate_interactive(
 
         # update generated ids, model inputs, and length for next step
         input_ids = torch.cat([input_ids, next_tokens[:, None]], dim=-1)
-        model_kwargs = model._update_model_kwargs_for_generation(
-            outputs, model_kwargs, is_encoder_decoder=False
-        )
+        model_kwargs = model._update_model_kwargs_for_generation(outputs, model_kwargs, is_encoder_decoder=False)
         unfinished_sequences = unfinished_sequences.mul((min(next_tokens != i for i in eos_token_id)).long())
-        
+
         output_token_ids = input_ids[0].cpu().tolist()
         output_token_ids = output_token_ids[input_length:]
         for each_eos_token_id in eos_token_id:

--- a/web_demo.py
+++ b/web_demo.py
@@ -53,9 +53,9 @@ system_meta_instruction = (
 - InternLM (书生·浦语) can understand and communicate fluently in the language chosen by the user such as English and 中文.
 """
 )
-user_prompt = "<|User|>:{user}<eoh>\n"
+user_prompt = "<|User|>:{user}\n"
 robot_prompt = "<|Bot|>:{robot}<eoa>\n"
-cur_query_prompt = "<|User|>:{user}<eoh>\n<|Bot|>:"
+cur_query_prompt = "<|User|>:{user}\n<|Bot|>:"
 
 
 def combine_history(prompt):

--- a/web_demo.py
+++ b/web_demo.py
@@ -36,9 +36,9 @@ def load_model():
 
 def prepare_generation_config():
     with st.sidebar:
-        max_length = st.slider("Max Length", min_value=32, max_value=2048, value=2048)
+        max_length = st.slider("Max Length", min_value=32, max_value=16000, value=8000)
         top_p = st.slider("Top P", 0.0, 1.0, 0.8, step=0.01)
-        temperature = st.slider("Temperature", 0.0, 1.0, 0.7, step=0.01)
+        temperature = st.slider("Temperature", 0.0, 1.0, 0.8, step=0.01)
         st.button("Clear Chat History", on_click=on_btn_click)
 
     generation_config = GenerationConfig(max_length=max_length, top_p=top_p, temperature=temperature)

--- a/web_demo_internlm.py
+++ b/web_demo_internlm.py
@@ -92,9 +92,9 @@ system_meta_instruction = (
 - InternLM (书生·浦语) can understand and communicate fluently in the language chosen by the user such as English and 中文.
 """
 )
-user_prompt = "<|User|>:{user}<eoh>\n"
+user_prompt = "<|User|>:{user}\n"
 robot_prompt = "<|Bot|>:{robot}<eoa>\n"
-cur_query_prompt = "<|User|>:{user}<eoh>\n<|Bot|>:"
+cur_query_prompt = "<|User|>:{user}\n<|Bot|>:"
 
 
 def combine_history(prompt):


### PR DESCRIPTION

This pr mainly provides function code for loading models in internlm format, as well as corresponding generation scripts and a wen_demo that can be used to directly load internlm models.

## Motivation

Support playing web_demo using internlm architecture instead of loading model checkpoints from huggingface.


## Modification

### internlm/apis/inference.py
1. Add code that can be used for streaming generation;
2. Add support for using multiple eos_token_id as end identifiers;
3. Remove some irrelevant code and comments.

### tools/load_internlm_model.py
1. Add functions that can be used to load the internlm format model;
2. Add sample code for model generation using internlm format;

### web_demo_internlm.py
Use models in internlm format to play web demos.


## Use cases (Optional)

Use the following command to run:
```python
torchrun --master_port 12331 --nnodes=1 --node_rank=0 --nproc_per_node=1 -m streamlit run web_demo_internlm.py
```



