### PR TITLE
fix(data): fix the unpack for type_ids when use_flash_attn=False

### DIFF
--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -359,7 +359,7 @@ def load_new_batch(train_dl: DataLoader, train_iter: Iterable, train_state: Trai
     if batch[0].get("type_ids", None) is not None:
         # if use_flash_attn is False, we need to unpack type_ids
         if not gpc.config.model.use_flash_attn:
-            batch[0]["type_ids"] = unpack_data(batch[0]["type_ids"], batch[0]["cu_seqlens"])
+            batch[0]["type_ids"] = unpack_data(batch[0]["type_ids"], batch[0]["cu_seqlens"], is_type_ids=True)
 
     return batch, train_iter
 


### PR DESCRIPTION

## Motivation

when the micro_num=1 and use_flash_attn=False, there is a bug in computing metrics.
The reason is the following: (use_flash_attn=False)
the shape of type_ids should be (micro_num, micro_bsz, max_length). In the unpack function, we can squeeze the first dimension if the first dimension is one. That is, the shape of type_ids could be (micro_bsz, max_length) when micro_num=1, which is incorrect resulting in a bug. The mico_num in the shape of type_ids should be kept though the micro_num is one.

## Modification
1. internlm/data/utils.py
2. internlm/train/training_internlm.py

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
