### PR TITLE
Feat(moe): merge operand to save kernel launch overhead

### DIFF
--- a/configs/7B_MoE8_sft.py
+++ b/configs/7B_MoE8_sft.py
@@ -144,6 +144,7 @@ model = dict(
     num_experts=8,
     moe_use_residual=False,
     moe_gate_k=2,
+    moe_noisy_gate_policy="RSample",
 )
 """
 zero1 parallel:

--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -306,6 +306,8 @@ def args_sanity_check():
             model._add_item("moe_use_residual", False)
         if "moe_gate_k" not in model:
             model._add_item("moe_gate_k", 2)
+        if "moe_noisy_gate_policy" not in model:
+            model._add_item("moe_noisy_gate_policy", None)
     # process the parallel config
     if "sequence_parallel" not in gpc.config.parallel:
         gpc.config.parallel._add_item("sequence_parallel", False)

--- a/internlm/moe/sharded_moe.py
+++ b/internlm/moe/sharded_moe.py
@@ -248,28 +248,40 @@ def top1gating(
     return l_aux, combine_weights, dispatch_mask, exp_counts
 
 
-def top2gating(logits: Tensor, capacity_factor: float, min_capacity: int) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+def top2gating(
+    logits: Tensor,
+    capacity_factor: float,
+    min_capacity: int,
+    noisy_gate_policy: Optional[str] = None,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     """Implements Top2Gating on logits."""
     # everything is in fp32 in this function
     gates = F.softmax(logits, dim=1)
+    num_experts = int(gates.shape[1])
 
     capacity = _capacity(gates, torch.tensor(capacity_factor * 2), torch.tensor(min_capacity))
 
-    # Create a mask for 1st's expert per token
-    indices1_s = torch.argmax(gates, dim=1)
-    num_experts = int(gates.shape[1])
-    mask1 = F.one_hot(indices1_s, num_classes=num_experts)
+    # NOTE: here we just add noise on 2nd expert, following
+    # https://github.com/facebookresearch/fairscale/blob/main/fairscale/nn/moe/top2gate.py
+    if noisy_gate_policy == "RSample":
+        # Create a mask for 1st's expert per token
+        indices1_s = torch.argmax(gates, dim=1)
+        mask1 = F.one_hot(indices1_s, num_classes=num_experts)
 
-    # Create a mask for 2nd's expert per token using Gumbel-max trick
-    # https://timvieira.github.io/blog/post/2014/07/31/gumbel-max-trick/
-    logits_w_noise = logits + gumbel_rsample(logits.shape, device=logits.device)
-    # Replace top-expert with min value
-    logits_except1 = logits_w_noise.masked_fill(mask1.bool(), torch.finfo(logits.dtype).min)
-    indices2_s = torch.argmax(logits_except1, dim=1)
-    mask2 = F.one_hot(indices2_s, num_classes=num_experts)
-
-    # merge operands in topk gating to save launch overhead
-    masks = torch.cat((mask1, mask2), dim=0)
+        # Create a mask for 2nd's expert per token using Gumbel-max trick
+        # https://timvieira.github.io/blog/post/2014/07/31/gumbel-max-trick/
+        logits_w_noise = logits + gumbel_rsample(logits.shape, device=logits.device)
+        # Replace top-expert with min value
+        logits_except1 = logits_w_noise.masked_fill(mask1.bool(), torch.finfo(logits.dtype).min)
+        indices2_s = torch.argmax(logits_except1, dim=1)
+        mask2 = F.one_hot(indices2_s, num_classes=num_experts)
+        # merge operands in topk gating to save launch overhead
+        masks = torch.cat((mask1, mask2), dim=0)
+    else:
+        # Create a mask by top-2 experts
+        indices_s = torch.topk(gates, 2, dim=1).indices
+        indices_s = indices_s.permute(1, 0).reshape(-1)
+        masks = F.one_hot(indices_s, num_classes=num_experts)
 
     # Compute locations in capacity buffer
     locations = torch.cumsum(masks, dim=0) - 1
@@ -376,7 +388,10 @@ class TopKGate(Module):
 
         else:
             gate_output = top2gating(
-                logits, self.capacity_factor if self.training else self.eval_capacity_factor, self.min_capacity
+                logits,
+                self.capacity_factor if self.training else self.eval_capacity_factor,
+                self.min_capacity,
+                self.noisy_gate_policy,
             )
 
         return gate_output


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In top2gating, there exist the same kernel computing for 1st and 2nd routing experts. This PR merge the operands into a single large kernel (e.g. mask1&mask2, location1&location2, etc.) to save kernel launch overhead.

tgs with 32 gpu and 32 experts:
| | 旧代码     | 新代码|
| ---------- | :-----------:  | :-----------: |
| TGS| 1958     | 2030     |

here is the loss comparison between new code and old code:
![1](https://github.com/InternLM/InternLM/assets/11952914/a8d9e27e-bc1c-435b-b7ba-1b0518ae95a3)

## Modification

1. internlm/moe/sharded_moe.py:
   * Refactoring codes with operands merging logic by stack two tensors with shape (s, e) into a single big tensor (2, s, e), then perform one kernel operation in the tensor. lines 287-319
   * If we do not add noise, the masks for 1st experts and 2nd experts generating can be further merged. lines 266-284
   * add new enisum logit. lines 102, 108, 114
2. internlm/initialize/launch.py: add moe_noisy_gate_policy options. 
3. configs/7B_MoE8_sft.py: rename to 7B_MoE8 since we have 8 experts in this config.



## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
