### PR TITLE
fix(model): add IS_SEQUENCE_PARALLEL check for norm module

### DIFF
--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -113,7 +113,8 @@ def initialize_model():
     model = wrap_FSDP_model(model)
 
     # check whether the norm module has IS_SEQUENCE_PARALLEL attribute
-    check_sequence_parallel(model)
+    if gpc.config.parallel.sequence_parallel is True:
+        check_sequence_parallel(model)
 
     return model
 

--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -53,6 +53,7 @@ from internlm.utils.common import DummyProfile
 from internlm.utils.logger import get_logger
 from internlm.utils.megatron_timers import megatron_timer as timer
 from internlm.utils.parallel import (
+    check_sequence_parallel,
     set_model_params_layer_name,
     sync_model_param,
     sync_model_param_within_tp,
@@ -110,6 +111,9 @@ def initialize_model():
 
     # if fsdp enabled, wrap the model
     model = wrap_FSDP_model(model)
+
+    # check whether the norm module has IS_SEQUENCE_PARALLEL attribute
+    check_sequence_parallel(model)
 
     return model
 

--- a/internlm/utils/parallel.py
+++ b/internlm/utils/parallel.py
@@ -105,13 +105,10 @@ def set_model_params_layer_name(model):
 
 def check_sequence_parallel(model):
     """
-    check whether the norm module has IS_SEQUENC_PARALLEL attribute.
-    when the sequence_parallel is True, the norm module should have the IS_SEQUENC_PARALLEL attribute
+    check whether the norm module has IS_SEQUENCE_PARALLEL attribute.
+    when the sequence_parallel is True, the norm module should have the IS_SEQUENCE_PARALLEL attribute
     to illustrate the norm should conduct the all-reduce for its grad.
     """
-
-    if gpc.config.parallel.sequence_parallel is False:
-        return
 
     if not isinstance(model, nn.ModuleList):
         model = [model]
@@ -124,6 +121,6 @@ def check_sequence_parallel(model):
             if isinstance(module, (RMSNorm, nn.LayerNorm)):
                 for param in module.parameters():
                     assert hasattr(param, IS_SEQUENCE_PARALLEL), (
-                        "when the sequence parallel is True,"
+                        "when the gpc.config.parallel.sequence parallel is True,"
                         "the params of norm module should have IS_SEQUENCE_PARALLEL attribute"
                     )

--- a/internlm/utils/parallel.py
+++ b/internlm/utils/parallel.py
@@ -120,7 +120,6 @@ def check_sequence_parallel(model):
         if isinstance(_chunk, NaiveAMPModel):
             _chunk = _chunk.model
         for _, children in _chunk.named_children():
-            # import pdb; pdb.set_trace()
             if isinstance(children, (RMSNorm, nn.LayerNorm)):
                 for param in children.parameters():
                     assert hasattr(param, IS_SEQUENCE_PARALLEL), (

--- a/internlm/utils/parallel.py
+++ b/internlm/utils/parallel.py
@@ -123,10 +123,10 @@ def check_sequence_parallel(model):
             # import pdb; pdb.set_trace()
             if isinstance(children, (RMSNorm, nn.LayerNorm)):
                 for param in children.parameters():
-                    assert hasattr(
-                        param, IS_SEQUENCE_PARALLEL
-                    ), ("when the sequence parallel is True,"
-                        "the params of norm module should have IS_SEQUENCE_PARALLEL attribute")
+                    assert hasattr(param, IS_SEQUENCE_PARALLEL), (
+                        "when the sequence parallel is True,"
+                        "the params of norm module should have IS_SEQUENCE_PARALLEL attribute"
+                    )
                 continue
             elif not isinstance(children, nn.ModuleList):
                 continue
@@ -135,7 +135,7 @@ def check_sequence_parallel(model):
                 for _, sub in block.named_children():
                     if isinstance(sub, (RMSNorm, nn.LayerNorm)):
                         for param in sub.parameters():
-                            assert hasattr(
-                                param, IS_SEQUENCE_PARALLEL
-                            ), ("when the sequence parallel is True,"
-                                "the params of norm module should have IS_SEQUENCE_PARALLEL attribute")
+                            assert hasattr(param, IS_SEQUENCE_PARALLEL), (
+                                "when the sequence parallel is True,"
+                                "the params of norm module should have IS_SEQUENCE_PARALLEL attribute"
+                            )

--- a/internlm/utils/parallel.py
+++ b/internlm/utils/parallel.py
@@ -119,22 +119,11 @@ def check_sequence_parallel(model):
     for _chunk in model:
         if isinstance(_chunk, NaiveAMPModel):
             _chunk = _chunk.model
-        for _, children in _chunk.named_children():
-            if isinstance(children, (RMSNorm, nn.LayerNorm)):
-                for param in children.parameters():
+        
+        for _, module in _chunk.named_modules():
+            if isinstance(module, (RMSNorm, nn.LayerNorm)):
+                for param in module.parameters():
                     assert hasattr(param, IS_SEQUENCE_PARALLEL), (
                         "when the sequence parallel is True,"
                         "the params of norm module should have IS_SEQUENCE_PARALLEL attribute"
                     )
-                continue
-            elif not isinstance(children, nn.ModuleList):
-                continue
-            # transformer block
-            for _, block in enumerate(children):  # iterate transformer blocks
-                for _, sub in block.named_children():
-                    if isinstance(sub, (RMSNorm, nn.LayerNorm)):
-                        for param in sub.parameters():
-                            assert hasattr(param, IS_SEQUENCE_PARALLEL), (
-                                "when the sequence parallel is True,"
-                                "the params of norm module should have IS_SEQUENCE_PARALLEL attribute"
-                            )

--- a/internlm/utils/parallel.py
+++ b/internlm/utils/parallel.py
@@ -119,7 +119,7 @@ def check_sequence_parallel(model):
     for _chunk in model:
         if isinstance(_chunk, NaiveAMPModel):
             _chunk = _chunk.model
-        
+
         for _, module in _chunk.named_modules():
             if isinstance(module, (RMSNorm, nn.LayerNorm)):
                 for param in module.parameters():


### PR DESCRIPTION

## Motivation

Add IS_SEQUENCE_PARALLEL check for norm module to adapt with different model so that the norm module could conduct grad all_reduce when sequence_parallel is True.

## Modification

internlm/train/training_internlm.py
internlm/utils/parallel.py

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.

