### PR TITLE
feat(ckpt): optimize model checkpointing in Volc and Ali

### DIFF
--- a/internlm/utils/model_checkpoint.py
+++ b/internlm/utils/model_checkpoint.py
@@ -859,8 +859,10 @@ class CheckpointManager:
 
         self.async_upload = get_config_value(ckpt_config, "async_upload", False)
 
+        if self.save_ckpt_folder.startswith("volc:") or self.save_ckpt_folder.startswith("oss2:"):
+            use_processpool = True
         # initialization storage manager
-        init_storage_manager(self.enable_save_ckpt, self.async_upload_tmp_folder, self.async_upload)
+        init_storage_manager(self.enable_save_ckpt, self.async_upload_tmp_folder, self.async_upload, use_processpool)
 
         self.feishu_address = feishu_address
         self.storage_manager = get_storage_manager()

--- a/internlm/utils/model_checkpoint.py
+++ b/internlm/utils/model_checkpoint.py
@@ -859,8 +859,9 @@ class CheckpointManager:
 
         self.async_upload = get_config_value(ckpt_config, "async_upload", False)
 
-        if self.save_ckpt_folder.startswith("volc:") or self.save_ckpt_folder.startswith("oss2:"):
-            use_processpool = True
+        use_processpool = self.save_ckpt_folder is not None and (
+            self.save_ckpt_folder.startswith("volc:") or self.save_ckpt_folder.startswith("oss2:")
+        )
         # initialization storage manager
         init_storage_manager(self.enable_save_ckpt, self.async_upload_tmp_folder, self.async_upload, use_processpool)
 

--- a/internlm/utils/storage_manager.py
+++ b/internlm/utils/storage_manager.py
@@ -9,22 +9,33 @@ dill.Pickler.dumps, dill.Pickler.loads = dill.dumps, dill.loads
 multiprocessing.reduction.ForkingPickler = dill.Pickler
 multiprocessing.reduction.dump = dill.dump
 
-import asyncio
-import concurrent.futures
-import hashlib
-import io
-import os
-import pickle
-import re
-import socket
-import stat
-from asyncio import InvalidStateError
-from asyncio.tasks import ALL_COMPLETED
-from datetime import datetime
-from typing import Any, Awaitable, Callable, Dict, List, Union
+import asyncio  # noqa: E402  #pylint: disable=wrong-import-position
+import concurrent.futures  # noqa: E402  #pylint: disable=wrong-import-position
+import hashlib  # noqa: E402  #pylint: disable=wrong-import-position
+import io  # noqa: E402  #pylint: disable=wrong-import-position
+import os  # noqa: E402  #pylint: disable=wrong-import-position
+import pickle  # noqa: E402  #pylint: disable=wrong-import-position
+import re  # noqa: E402  #pylint: disable=wrong-import-position
+import socket  # noqa: E402  #pylint: disable=wrong-import-position
+import stat  # noqa: E402  #pylint: disable=wrong-import-position
+from asyncio import (  # noqa: E402  #pylint: disable=wrong-import-position
+    InvalidStateError,
+)
+from asyncio.tasks import (  # noqa: E402  #pylint: disable=wrong-import-position
+    ALL_COMPLETED,
+)
+from datetime import datetime  # noqa: E402  #pylint: disable=wrong-import-position
+from typing import (  # noqa: E402  #pylint: disable=wrong-import-position
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Union,
+)
 
-import torch
-import torch.distributed as dist
+import torch  # noqa: E402  #pylint: disable=wrong-import-position
+import torch.distributed as dist  # noqa: E402  #pylint: disable=wrong-import-position
 
 try:
     import boto3


### PR DESCRIPTION
## Motivation

Due to python GIL, training throughput (measured by tgs) will be affected when we asynchronously upload ckpt via `concurrent.futures.ThreadPoolExecutor`. 
Therefore, we switch to use `concurrent.futures.ProcessPoolExecutor` to async upload ckpts, which has nearly no overhead on the training performance.

## Implementation

1. For Aliyun OSS2 and Volc TOS, we switch to use `concurrent.futures.ProcessPoolExecutor` to upload checkpoints to object storage. Our comparative test results show that using multiple processes can reduce the overhead of async uploading to almost negligible.
2. Use [`dill`](https://github.com/uqfoundation/dill) to hijack default `pickle` serialization/deserialization implementation in `multiprocessing`

## BC-breaking (Optional)

None

## Use cases (Optional)

We conducted a comparative test on the 65B model

1. For Volc, we can see that training throughput (measured by tgs) will be **improved from ~70 to 145**, and the affected steps will be **reduced from several dozens to one step**.

- When use `ThreadPoolExecutor` to async upload ckpt, the **overhead is huge**:  the tgs of affected steps **decay from 148 to ~70** and **at least dozens of steps will be affected** (Because python multithreading is fake multithreading thanks to GIL, causing CPU time to be occupied by async upload)

![image](https://github.com/InternLM/InternLM/assets/8370601/d16413c7-f726-43b7-9002-d640532a7afb)

-  When use `ProcessPoolExecutor` to async upload ckpt, the **overhead is very small**: the tgs of affected steps **decay from 148 to 145** and **only one steps will be affected** (overhead only comes from inter-process communication)

![image](https://github.com/InternLM/InternLM/assets/8370601/95e078d0-90dd-498e-a242-606a4e60be98)

3. Our implementation also works for Aliyun. We can see that training throughput (measured by tgs) will be **improved from ~120 to 143**, and the affected steps will be **reduced from several dozens to one step**.

- When use `ThreadPoolExecutor` to async upload ckpt, the **overhead is huge**:  the tgs of affected steps **decay from 148 to ~120** and **at least dozens of steps will be affected** (Because python multithreading is fake multithreading thanks to GIL, causing CPU time to be occupied by async upload)

![image](https://github.com/InternLM/InternLM/assets/8370601/8d8da589-5623-424b-b7cd-5e345ff9c082)

-  When use `ProcessPoolExecutor` to async upload ckpt, the **overhead is very small**: the tgs of affected steps **decay from 150 to 143** and **only one steps will be affected** (overhead only comes from inter-process communication)

![image](https://github.com/InternLM/InternLM/assets/8370601/7be06fd8-a578-433c-8f76-8b29b9e2f8b7)


## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
