### PR TITLE
fix(gc): fix oom issue in dataloaders

### DIFF
--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -2,7 +2,6 @@
 # -*- encoding: utf-8 -*-
 
 import argparse
-import gc
 import os
 from pathlib import Path
 from typing import Dict, Union

--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -533,9 +533,6 @@ def initialize_distributed_env(
         seed (int, optional): Specified random seed for every process. 1024 by default.
     """
 
-    # close automatic garbage collection
-    gc.disable()
-
     torch.cuda.empty_cache()
 
     if launcher == "torch":

--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -263,8 +263,8 @@ def get_train_data_loader(num_worker: int = 0, dataset_generate_func: Optional[C
             data_world_size=gpc.get_world_size(ParallelMode.DATA),
         )
         train_collate_fn = partial(packed_collate_fn, packed_length=data_cfg.packed_length)
-    
-    def dl_worker_init(worker_id):
+
+    def dl_worker_init(worker_id):  # pylint: disable=unused-argument
         gc.enable()
 
     # Create the training data loader
@@ -275,7 +275,7 @@ def get_train_data_loader(num_worker: int = 0, dataset_generate_func: Optional[C
         pin_memory=True,
         collate_fn=train_collate_fn,
         persistent_workers=num_worker > 0,
-        worker_init_fn = dl_worker_init,
+        worker_init_fn=dl_worker_init,
     )
 
     return train_dl, dataset_types

--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -2,7 +2,6 @@
 # -*- encoding: utf-8 -*-
 
 import functools
-import gc
 import os
 import pickle
 import time
@@ -264,9 +263,6 @@ def get_train_data_loader(num_worker: int = 0, dataset_generate_func: Optional[C
         )
         train_collate_fn = partial(packed_collate_fn, packed_length=data_cfg.packed_length)
 
-    def dl_worker_init(worker_id):  # pylint: disable=unused-argument
-        gc.enable()
-
     # Create the training data loader
     train_dl = DataLoader(
         dataset=train_ds,
@@ -275,7 +271,6 @@ def get_train_data_loader(num_worker: int = 0, dataset_generate_func: Optional[C
         pin_memory=True,
         collate_fn=train_collate_fn,
         persistent_workers=num_worker > 0,
-        worker_init_fn=dl_worker_init,
     )
 
     return train_dl, dataset_types

--- a/internlm/train/training_internlm.py
+++ b/internlm/train/training_internlm.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 
 import functools
+import gc
 import os
 import pickle
 import time
@@ -262,6 +263,9 @@ def get_train_data_loader(num_worker: int = 0, dataset_generate_func: Optional[C
             data_world_size=gpc.get_world_size(ParallelMode.DATA),
         )
         train_collate_fn = partial(packed_collate_fn, packed_length=data_cfg.packed_length)
+    
+    def dl_worker_init(worker_id):
+        gc.enable()
 
     # Create the training data loader
     train_dl = DataLoader(
@@ -271,6 +275,7 @@ def get_train_data_loader(num_worker: int = 0, dataset_generate_func: Optional[C
         pin_memory=True,
         collate_fn=train_collate_fn,
         persistent_workers=num_worker > 0,
+        worker_init_fn = dl_worker_init,
     )
 
     return train_dl, dataset_types

--- a/train.py
+++ b/train.py
@@ -192,10 +192,9 @@ def main(args):
     # transfer the train data loader into train data iterator
     train_iter = iter(train_dl)
 
-    # close automatic garbage collection
-    gc.disable()
-
     with initialize_llm_profile(profiling=args.profiling, start_time=current_time) as prof:
+        # close automatic garbage collection
+        gc.disable()
         # start iterating the train data and begin training
         for batch_count in range(train_state.batch_count, total_steps):
             empty_cache_and_diag(batch_count, interval=gpc.config.data.empty_cache_and_diag_interval)

--- a/train.py
+++ b/train.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 
+import gc
 import socket
 import time
 import traceback
@@ -190,6 +191,9 @@ def main(args):
 
     # transfer the train data loader into train data iterator
     train_iter = iter(train_dl)
+
+    # close automatic garbage collection
+    gc.disable()
 
     with initialize_llm_profile(profiling=args.profiling, start_time=current_time) as prof:
         # start iterating the train data and begin training


### PR DESCRIPTION
## Motivation

We observe that after training for a period of time, OOM raised from the dataloader workers. Memory leak will be more severe  if you are using stream dataloader.

## Implementation

1. (**Optional** if we set `gc.disable()` after launching dataloader worker) We manually enable automatic GC in dataloader `worker_init_fn` to avoid OOM caused by multiprocessing
2. Move `gc.disable()` to the line just before train loop starts: Minimize the scope of manual GC (to optimize training throughput), and keep other part automatic GC (to avoid memory leaking)
3. Workaround the copy-on-access problem caused by python multiprocessing and `fork()` start method. We force multiprocessing to use `spawn` start method to fix memory leak.

## BC-breaking (Optional)

None

## Use cases (Optional)

None

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
