### PR TITLE
feat(logger): add tensorboard key value buffer

### DIFF
--- a/configs/7B_sft.py
+++ b/configs/7B_sft.py
@@ -176,6 +176,9 @@ monitor = dict(
         light_monitor_address=None,  # light_monitor address to send heartbeat
         alert_file_path=f"llm_alter/{JOB_NAME}_alert.log",
     ),
+    tensorboard=dict(
+        queue_max_length=10,
+    ),
 )
 
 # metric_dtype can be "fp32" or other string

--- a/internlm/initialize/launch.py
+++ b/internlm/initialize/launch.py
@@ -332,6 +332,9 @@ def args_sanity_check():
                 "alert_file_path": None,
             }
         },
+        "tensorboard": {
+            "queue_max_length": 1,
+        },
     }
 
     for key, value in monitor_default_config.items():

--- a/train.py
+++ b/train.py
@@ -138,7 +138,7 @@ def main(args):
         config=config_lines,
         logger=logger,
         enable_tb=gpc.config.enable_tb,
-        queue_max_length=gpc.config.monitor.tensorboard.queue_max_length,
+        queue_max_length=gpc.config.tensorboard.queue_max_length,
         total_steps=total_steps,
     )
 

--- a/train.py
+++ b/train.py
@@ -138,6 +138,8 @@ def main(args):
         config=config_lines,
         logger=logger,
         enable_tb=gpc.config.enable_tb,
+        queue_max_length=gpc.config.monitor.tensorboard.queue_max_length,
+        total_steps=total_steps,
     )
 
     # initialize metric for calculating accuracy and perplexity


### PR DESCRIPTION
In delay-sensitive training, the writing time overhead of tensorboard is not negligible. We add a new config parameter `queue_max_length` to support batch writing of tensorboard.

```python
monitor = dict(
    tensorboard=dict(
        queue_max_length=10,
    ),
)

```

![image](https://github.com/InternLM/InternLM/assets/32697156/edc9a73f-e9cc-4ec5-af73-481d5a7c3cc8)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
