### PR TITLE
fix(chat): fix stream_chat in modeling_internlm(hf) to avoid decode error

### DIFF
--- a/tools/transformers/modeling_internlm.py
+++ b/tools/transformers/modeling_internlm.py
@@ -844,6 +844,7 @@ class InternLMForCausalLM(InternLMPreTrainedModel):
                 self.query = query
                 self.history = history
                 self.response = ""
+                self.chche = []
                 self.received_inputs = False
                 self.queue.put((self.response, history + [(self.query, self.response)]))
 
@@ -858,11 +859,18 @@ class InternLMForCausalLM(InternLMPreTrainedModel):
                     self.received_inputs = True
                     return
 
-                token = self.tokenizer.decode([value[-1]], skip_special_tokens=True)
+                self.chche.extend(value.tolist())
+                token = self.tokenizer.decode(self.chche, skip_special_tokens=True)
+                if " " in token and len(token) <= 5:
+                    return
+                
                 if token.strip() != "<eoa>":
                     self.response = self.response + token
                     history = self.history + [(self.query, self.response)]
                     self.queue.put((self.response, history))
+                    self.chche = []
+                else:
+                    self.end()
 
             def end(self):
                 self.queue.put(None)

--- a/tools/transformers/modeling_internlm.py
+++ b/tools/transformers/modeling_internlm.py
@@ -844,7 +844,7 @@ class InternLMForCausalLM(InternLMPreTrainedModel):
                 self.query = query
                 self.history = history
                 self.response = ""
-                self.chche = []
+                self.cache = []
                 self.received_inputs = False
                 self.queue.put((self.response, history + [(self.query, self.response)]))
 
@@ -859,8 +859,8 @@ class InternLMForCausalLM(InternLMPreTrainedModel):
                     self.received_inputs = True
                     return
 
-                self.chche.extend(value.tolist())
-                token = self.tokenizer.decode(self.chche, skip_special_tokens=True)
+                self.cache.extend(value.tolist())
+                token = self.tokenizer.decode(self.cache, skip_special_tokens=True)
                 if "�" in token and len(token) <= 5:
                     return
                 
@@ -868,7 +868,7 @@ class InternLMForCausalLM(InternLMPreTrainedModel):
                     self.response = self.response + token
                     history = self.history + [(self.query, self.response)]
                     self.queue.put((self.response, history))
-                    self.chche = []
+                    self.cache = []
                 else:
                     self.end()
 

--- a/tools/transformers/modeling_internlm.py
+++ b/tools/transformers/modeling_internlm.py
@@ -861,7 +861,7 @@ class InternLMForCausalLM(InternLMPreTrainedModel):
 
                 self.chche.extend(value.tolist())
                 token = self.tokenizer.decode(self.chche, skip_special_tokens=True)
-                if " " in token and len(token) <= 5:
+                if "�" in token and len(token) <= 5:
                     return
                 
                 if token.strip() != "<eoa>":


### PR DESCRIPTION
①在流式回复stream_chat方法中，引入token缓存解码机制，之前的逻辑是出来一个token，解码这个token并加入到response，现在的逻辑是：如果当前token解码出的文本是乱码，则先缓存token，继续生成下一个step的token，直到能解码出明文或者缓存长度超出限制（5个token）

②在流式回复stream_chat方法中，原先逻辑是如果当前token解码后不是“eoa”，则将解码后的文本加入到response，但并没有对结束generate的条件进行判定，因此加入结束生成的判定：如果当前token解码后是“eoa”，则直接结束

测试问题：query="凌和淩有什么不同？"
代码如下：
```
class ChatStreamer(BaseStreamer):
            def __init__(self, tokenizer) -> None:
                super().__init__()
                self.tokenizer = tokenizer
                self.queue = response_queue
                self.query = query
                self.history = history
                self.response = ""
                self.chche = []
                self.received_inputs = False
                self.queue.put((self.response, history + [(self.query, self.response)]))

            def put(self, value):
                if len(value.shape) > 1 and value.shape[0] > 1:
                    raise ValueError("ChatStreamer only supports batch size 1")
                elif len(value.shape) > 1:
                    value = value[0]

                if not self.received_inputs:
                    # The first received value is input_ids, ignore here
                    self.received_inputs = True
                    return

                self.chche.extend(value.tolist())
                token = self.tokenizer.decode(self.chche, skip_special_tokens=True)
                if "�" in token and len(token) <= 5:
                    return
                
                if token.strip() != "<eoa>":
                    self.response = self.response + token
                    history = self.history + [(self.query, self.response)]
                    self.queue.put((self.response, history))
                    self.chche = []
                else:
                    self.end()
```