### PR TITLE
fix(utils): fix split cuda memory leak

### DIFF
--- a/internlm/model/utils.py
+++ b/internlm/model/utils.py
@@ -36,7 +36,11 @@ def _split(input_, parallel_mode, dim=-1):
 
     tensor_list = torch.split(input_, dim_size // world_size, dim=dim)
     rank = gpc.get_local_rank(parallel_mode)
-    output = tensor_list[rank].contiguous()
+
+    # After splitting, the small chunk will share the same storage space with the large tensor.
+    # We will need to clone the small chunk, which will create a new storage, otherwise it
+    # will hinder the large tensor's CUDA memory GC.
+    output = tensor_list[rank].contiguous().clone()
 
     return output
 


### PR DESCRIPTION
## Motivation

`_split()` in utils.py has cuda memory leak problem, it will cause unnecessary memory occupation and lead to cuda OOM.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
