### PR TITLE
Add missing dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 sentencepiece
 streamlit
 transformers>=4.34
+protobuf
+accelerate
+einops


### PR DESCRIPTION
Added missing dependencies (`protobuf`, `accelerate`, `einops`) to `requirements.txt` to fix the setup issues encountered during the demo run. 
