### PR TITLE
[CI]: Add flash_attn installation in testcase and update transformers requirement

### DIFF
--- a/.github/workflows/daily_tests.yaml
+++ b/.github/workflows/daily_tests.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [t_cluster]
     strategy:
       matrix:
-        transformers-version: [4.36.0, latest]
+        transformers-version: [4.38.0, latest]
     steps:
     - name: mask env
       run: |

--- a/.github/workflows/daily_tests.yaml
+++ b/.github/workflows/daily_tests.yaml
@@ -27,6 +27,9 @@ jobs:
         conda create -n internlm-model-latest --clone ${CONDA_BASE_ENV}
         source activate internlm-model-latest
         pip install transformers==${{ matrix.transformers-version }}
+        pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu118
+        wget https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.8/flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
+        pip install flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
         pip install sentencepiece auto-gptq==0.6.0 lmdeploy[all]
         srun -p ${SLURM_PARTITION} --kill-on-bad-exit=1 --job-name=${GITHUB_RUN_ID}-${GITHUB_JOB} --gpus-per-task=2 pytest -s -v --color=yes ./tests/test_hf_model.py
         conda deactivate

--- a/.github/workflows/daily_tests.yaml
+++ b/.github/workflows/daily_tests.yaml
@@ -35,7 +35,6 @@ jobs:
         pip install transformers
     - name: run_test
       run: |
-        conda create -n internlm-model-latest --clone ${CONDA_BASE_ENV}
         source activate internlm-model-latest
         pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu118
         wget https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.8/flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl

--- a/.github/workflows/daily_tests.yaml
+++ b/.github/workflows/daily_tests.yaml
@@ -27,18 +27,19 @@ jobs:
         conda create -n internlm-model-latest --clone ${CONDA_BASE_ENV}
         source activate internlm-model-latest
         pip install transformers==${{ matrix.transformers-version }}
-        pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu118
-        wget https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.8/flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
-        pip install flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
-        pip install sentencepiece auto-gptq==0.6.0 lmdeploy[all]
-        srun -p ${SLURM_PARTITION} --kill-on-bad-exit=1 --job-name=${GITHUB_RUN_ID}-${GITHUB_JOB} --gpus-per-task=2 pytest -s -v --color=yes ./tests/test_hf_model.py
-        conda deactivate
     - name: load_latest_hf_model
       if: matrix.transformers-version == 'latest'
       run: |
         conda create -n internlm-model-latest --clone ${CONDA_BASE_ENV}
         source activate internlm-model-latest
         pip install transformers
+    - name: run_test
+      run: |
+        conda create -n internlm-model-latest --clone ${CONDA_BASE_ENV}
+        source activate internlm-model-latest
+        pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu118
+        wget https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.8/flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
+        pip install flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
         pip install sentencepiece auto-gptq==0.6.0 lmdeploy[all]
         srun -p ${SLURM_PARTITION} --kill-on-bad-exit=1 --job-name=${GITHUB_RUN_ID}-${GITHUB_JOB} --gpus-per-task=2 pytest -s -v --color=yes ./tests/test_hf_model.py
         conda deactivate

--- a/.github/workflows/daily_tests.yaml
+++ b/.github/workflows/daily_tests.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [t_cluster]
     strategy:
       matrix:
-        transformers-version: [4.34.0, latest]
+        transformers-version: [4.36.0, latest]
     steps:
     - name: mask env
       run: |
@@ -37,8 +37,7 @@ jobs:
       run: |
         source activate internlm-model-latest
         pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu118
-        wget https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.8/flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
-        pip install flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
+        pip install /mnt/petrelfs/qa-caif-cicd/resource/flash_attn-2.5.8+cu118torch2.2cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
         pip install sentencepiece auto-gptq==0.6.0 lmdeploy[all]
         srun -p ${SLURM_PARTITION} --kill-on-bad-exit=1 --job-name=${GITHUB_RUN_ID}-${GITHUB_JOB} --gpus-per-task=2 pytest -s -v --color=yes ./tests/test_hf_model.py
         conda deactivate

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The release of InternLM2 series contains two model sizes: 7B and 20B. 7B models 
 
 - Python >= 3.8
 - PyTorch >= 1.12.0 (2.0.0 and above are recommended)
-- Transformers >= 4.34
+- Transformers >= 4.38
 
 ## Usages
 
@@ -147,7 +147,7 @@ The chat models adopt [chatml format](./chat/chat_format.md) to support both cha
 To ensure a better usage effect, please make sure that the installed transformers library version meets the following requirements before performing inference with [Transformers](#import-from-transformers) or [ModelScope](#import-from-modelscope):
 
 ```
-transformers >= 4.34
+transformers >= 4.38
 ```
 
 ### Import from Transformers
@@ -202,7 +202,7 @@ You can interact with the InternLM Chat 7B model through a frontend interface by
 
 ```bash
 pip install streamlit
-pip install transformers>=4.34
+pip install transformers>=4.38
 streamlit run ./chat/web_demo.py
 ```
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -135,7 +135,7 @@ InternLM2 系列模型在本仓库正式发布，具有如下特性：
 
 - Python >= 3.8
 - PyTorch >= 1.12.0 (推荐 2.0.0 和更高版本)
-- Transformers >= 4.34
+- Transformers >= 4.38
 
 ## 使用案例
 
@@ -144,7 +144,7 @@ InternLM2 系列模型在本仓库正式发布，具有如下特性：
 为了保障更好的使用效果，在用 [Transformers](#import-from-transformers) 或 [ModelScope](#import-from-modelscope) 进行推理前，请确保安装的 transformers 库版本满足以下要求：
 
 ```
-transformers >= 4.34
+transformers >= 4.38
 ```
 
 ### 通过 Transformers 加载
@@ -198,7 +198,7 @@ print(response)
 
 ```bash
 pip install streamlit
-pip install transformers>=4.34
+pip install transformers>=4.38
 streamlit run ./chat/web_demo.py
 ```
 

--- a/chat/README.md
+++ b/chat/README.md
@@ -52,7 +52,7 @@ You can interact with the InternLM Chat 7B model through a frontend interface by
 
 ```bash
 pip install streamlit
-pip install transformers>=4.34
+pip install transformers>=4.38
 streamlit run ./chat/web_demo.py
 ```
 

--- a/chat/README_zh-CN.md
+++ b/chat/README_zh-CN.md
@@ -46,6 +46,6 @@ print(response)
 
 ```bash
 pip install streamlit
-pip install transformers>=4.34
+pip install transformers>=4.38
 streamlit run ./web_demo.py
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sentencepiece
 streamlit
-transformers>=4.34
+transformers>=4.38


### PR DESCRIPTION
1. the newest internlm2's hf model needs flash_attn, add flash_attn installation in test case workflow
2. the newest internlm2's hf model use transformers's static cache which is supported in version 4.38. Update releated docs. 

test workflow is https://github.com/InternLM/InternLM/actions/runs/9560759361